### PR TITLE
Refactor crypto modules

### DIFF
--- a/src/certificate_chain.rs
+++ b/src/certificate_chain.rs
@@ -4,7 +4,8 @@
 #[cfg(not(any(feature = "online", target_arch = "wasm32")))]
 compile_error!("certificate_chain module requires either the 'online' feature or wasm32 target");
 
-use crate::crypto::{Certificate, Verifier};
+use crate::crypto::verifier::Sync as Verifier;
+use crate::crypto::Certificate;
 use crate::kds::KdsFetcher;
 use crate::pinned_arks;
 use crate::{snp, AttestationReport};

--- a/src/crypto/crypto_openssl.rs
+++ b/src/crypto/crypto_openssl.rs
@@ -11,14 +11,15 @@ use openssl_sys::{
     X509_get_ext_by_OBJ,
 };
 
-use super::{CryptoBackend, Result, Verifier};
+use super::verifier::Sync as Verifier;
+use super::{CertificateBackend, CryptoBackend, Result};
 use crate::snp::report::{AttestationReport, Signature};
 
 pub struct Crypto;
 
 type Certificate = openssl::x509::X509;
 
-impl CryptoBackend for Crypto {
+impl CertificateBackend for Crypto {
     type Certificate = Certificate;
 
     fn from_pem(pem: &[u8]) -> Result<Self::Certificate> {
@@ -44,29 +45,6 @@ impl CryptoBackend for Crypto {
             .to_pem()
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
         String::from_utf8(pem).map_err(|e| format!("Failed to decode PEM as UTF-8: {:?}", e).into())
-    }
-
-    fn verify_chain(
-        trusted_certs: &[&Certificate],
-        untrusted_chain: &[&Certificate],
-        leaf: &Certificate,
-    ) -> Result<()> {
-        let mut store_builder = openssl::x509::store::X509StoreBuilder::new()?;
-        for cert in trusted_certs {
-            store_builder.add_cert((*cert).to_owned())?;
-        }
-        store_builder.set_flags(X509VerifyFlags::PARTIAL_CHAIN)?;
-        let store = store_builder.build();
-        let mut ctx = openssl::x509::X509StoreContext::new()?;
-        let mut chain = Stack::<Certificate>::new()?;
-        for cert in untrusted_chain {
-            chain.push((*cert).to_owned())?;
-        }
-        match ctx.init(&store, leaf, &chain, |c| c.verify_cert()) {
-            Ok(true) => Ok(()),
-            Ok(false) => Err("Certificate verification failed".into()),
-            Err(e) => Err(Box::new(e)),
-        }
     }
 
     fn get_public_key(cert: &Self::Certificate) -> Result<Vec<u8>> {
@@ -110,9 +88,34 @@ impl CryptoBackend for Crypto {
     }
 }
 
+impl CryptoBackend for Crypto {
+    fn verify_chain(
+        trusted_certs: &[&Certificate],
+        untrusted_chain: &[&Certificate],
+        leaf: &Certificate,
+    ) -> Result<()> {
+        let mut store_builder = openssl::x509::store::X509StoreBuilder::new()?;
+        for cert in trusted_certs {
+            store_builder.add_cert((*cert).to_owned())?;
+        }
+        store_builder.set_flags(X509VerifyFlags::PARTIAL_CHAIN)?;
+        let store = store_builder.build();
+        let mut ctx = openssl::x509::X509StoreContext::new()?;
+        let mut chain = Stack::<Certificate>::new()?;
+        for cert in untrusted_chain {
+            chain.push((*cert).to_owned())?;
+        }
+        match ctx.init(&store, leaf, &chain, |c| c.verify_cert()) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err("Certificate verification failed".into()),
+            Err(e) => Err(Box::new(e)),
+        }
+    }
+}
+
 impl Verifier<Certificate> for Certificate {
     fn verify(&self, other: &Certificate) -> Result<()> {
-        Crypto::verify_chain(&[self], &[], other)
+        <Crypto as CryptoBackend>::verify_chain(&[self], &[], other)
     }
 }
 

--- a/src/crypto/crypto_pure_rust.rs
+++ b/src/crypto/crypto_pure_rust.rs
@@ -3,60 +3,42 @@
 
 use p384::ecdsa::VerifyingKey as EcdsaVerifyingKey;
 use rsa::{
+    pkcs8::DecodePublicKey,
     pss::{Signature as PssSignature, VerifyingKey as PssVerifyingKey},
     RsaPublicKey,
 };
 use sha2::Sha384;
-use x509_cert::der::{
-    oid::ObjectIdentifier, pem::LineEnding, referenced::OwnedToRef, Decode, DecodePem, Encode,
-    EncodePem,
-};
 
+use super::x509_certificate::{Certificate, SignatureAlgorithm};
 use super::{CryptoBackend, Result, Verifier};
 use crate::snp::report::{AttestationReport, Signature};
 
 pub struct Crypto;
 
-type Certificate = x509_cert::Certificate;
-
-mod oid {
-    use x509_cert::der::oid::ObjectIdentifier;
-
-    // RSA-PSS (1.2.840.113549.1.1.10)
-    pub const RSA_PSS: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
-}
-
 impl Verifier<Certificate> for Certificate {
     fn verify(&self, subject: &Certificate) -> Result<()> {
-        // Encode the TBS (to-be-signed) portion of the subject certificate
-        let tbs_bytes = subject
-            .tbs_certificate
-            .to_der()
-            .map_err(|e| format!("Failed to encode TBS certificate: {:?}", e))?;
+        let tbs_bytes = subject.tbs_certificate_der()?;
+        let sig_bytes = subject.signature_bytes();
+        let issuer_spki = self.public_key_spki_der()?;
 
-        let sig_bytes = subject.signature.raw_bytes();
-        let sig_algo_oid = &subject.signature_algorithm.oid;
-        let issuer_spki = &self.tbs_certificate.subject_public_key_info;
+        match subject.signature_algorithm()? {
+            SignatureAlgorithm::RsaPss => {
+                use rsa::signature::Verifier;
 
-        if *sig_algo_oid == oid::RSA_PSS {
-            // RSA-PSS with SHA-384
-            use rsa::signature::Verifier;
+                let rsa_pub = RsaPublicKey::from_public_key_der(&issuer_spki)
+                    .map_err(|e| format!("Failed to parse RSA public key: {:?}", e))?;
 
-            let rsa_pub = RsaPublicKey::try_from(issuer_spki.owned_to_ref())
-                .map_err(|e| format!("Failed to parse RSA public key: {:?}", e))?;
+                let verifying_key = PssVerifyingKey::<Sha384>::new(rsa_pub);
 
-            let verifying_key = PssVerifyingKey::<Sha384>::new(rsa_pub);
+                let sig = PssSignature::try_from(sig_bytes)
+                    .map_err(|e| format!("Failed to parse RSA-PSS signature: {:?}", e))?;
 
-            let sig = PssSignature::try_from(sig_bytes)
-                .map_err(|e| format!("Failed to parse RSA-PSS signature: {:?}", e))?;
+                verifying_key
+                    .verify(&tbs_bytes, &sig)
+                    .map_err(|e| format!("RSA-PSS signature verification failed: {:?}", e))?;
 
-            verifying_key
-                .verify(&tbs_bytes, &sig)
-                .map_err(|e| format!("RSA-PSS signature verification failed: {:?}", e))?;
-
-            Ok(())
-        } else {
-            Err(format!("Unsupported signature algorithm OID: {}", sig_algo_oid).into())
+                Ok(())
+            }
         }
     }
 }
@@ -65,30 +47,23 @@ impl CryptoBackend for Crypto {
     type Certificate = Certificate;
 
     fn from_pem(pem: &[u8]) -> Result<Self::Certificate> {
-        let pem_str =
-            std::str::from_utf8(pem).map_err(|e| format!("Invalid UTF-8 in PEM data: {:?}", e))?;
-        Certificate::from_pem(pem_str)
-            .map_err(|e| format!("Failed to parse PEM certificate: {:?}", e).into())
+        Certificate::from_pem(pem)
     }
 
     fn from_pem_chain(pem: &[u8]) -> Result<Vec<Self::Certificate>> {
-        Certificate::load_pem_chain(pem)
-            .map_err(|e| format!("Failed to parse PEM certificate chain: {:?}", e).into())
+        Certificate::from_pem_chain(pem)
     }
 
     fn from_der(der: &[u8]) -> Result<Self::Certificate> {
         Certificate::from_der(der)
-            .map_err(|e| format!("Failed to parse DER certificate: {:?}", e).into())
     }
 
     fn to_der(cert: &Self::Certificate) -> Result<Vec<u8>> {
         cert.to_der()
-            .map_err(|e| format!("Failed to encode certificate as DER: {:?}", e).into())
     }
 
     fn to_pem(cert: &Self::Certificate) -> Result<String> {
-        cert.to_pem(LineEnding::LF)
-            .map_err(|e| format!("Failed to encode certificate as PEM: {:?}", e).into())
+        cert.to_pem()
     }
 
     fn verify_chain(
@@ -97,7 +72,7 @@ impl CryptoBackend for Crypto {
         leaf: &Certificate,
     ) -> Result<()> {
         let untrusted_chain = untrusted_chain.iter().chain(std::iter::once(&leaf));
-        let mut prev: Option<&x509_cert::certificate::CertificateInner> = None;
+        let mut prev: Option<&Certificate> = None;
         for cert in untrusted_chain {
             if let Some(issuer) = prev {
                 issuer.verify(*cert)?;
@@ -113,25 +88,11 @@ impl CryptoBackend for Crypto {
     }
 
     fn get_public_key(cert: &Self::Certificate) -> Result<Vec<u8>> {
-        cert.tbs_certificate
-            .subject_public_key_info
-            .to_der()
-            .map_err(|e| format!("Failed to encode SubjectPublicKeyInfo: {:?}", e).into())
+        cert.public_key_spki_der()
     }
 
     fn get_extension_value_by_oid(cert: &Self::Certificate, oid: &str) -> Result<Option<Vec<u8>>> {
-        let oid = ObjectIdentifier::new(oid)
-            .map_err(|e| format!("Invalid extension OID {}: {:?}", oid, e))?;
-
-        let extensions = match cert.tbs_certificate.extensions.as_ref() {
-            Some(extensions) => extensions,
-            None => return Ok(None),
-        };
-
-        Ok(extensions
-            .iter()
-            .find(|extension| extension.extn_id == oid)
-            .map(|extension| extension.extn_value.as_bytes().to_vec()))
+        cert.get_extension_value_by_oid(oid)
     }
 }
 
@@ -140,20 +101,25 @@ fn verify_report_sig_ecdsa_p384_sha384(
     signed_bytes: &[u8],
     signature: Signature,
 ) -> Result<()> {
-    let vcek_pub = vcek
-        .tbs_certificate
-        .subject_public_key_info
-        .subject_public_key
-        .raw_bytes();
+    let vcek_pub = vcek.subject_public_key_bytes();
 
     let vk = EcdsaVerifyingKey::from_sec1_bytes(vcek_pub)
         .map_err(|e| format!("Failed to parse ECDSA public key: {:?}", e))?;
 
-    // P-384 scalars are 48 bytes each, extract from the 72-byte arrays
+    if signature.r[48..].iter().any(|byte| *byte != 0) {
+        return Err(
+            "Invalid r scalar padding: upper 24 bytes must be zero for P-384 signatures".into(),
+        );
+    }
     let mut r_bytes: [u8; 48] = signature.r[..48]
         .try_into()
         .map_err(|_| "Invalid r scalar length")?;
     r_bytes.reverse();
+    if signature.s[48..].iter().any(|byte| *byte != 0) {
+        return Err(
+            "Invalid s scalar padding: upper 24 bytes must be zero for P-384 signatures".into(),
+        );
+    }
     let mut s_bytes: [u8; 48] = signature.s[..48]
         .try_into()
         .map_err(|_| "Invalid s scalar length")?;

--- a/src/crypto/crypto_pure_rust.rs
+++ b/src/crypto/crypto_pure_rust.rs
@@ -9,8 +9,9 @@ use rsa::{
 };
 use sha2::Sha384;
 
+use super::verifier::Sync as Verifier;
 use super::x509_certificate::{Certificate, SignatureAlgorithm};
-use super::{CryptoBackend, Result, Verifier};
+use super::{CertificateBackend, CryptoBackend, Result};
 use crate::snp::report::{AttestationReport, Signature};
 
 pub struct Crypto;
@@ -43,7 +44,7 @@ impl Verifier<Certificate> for Certificate {
     }
 }
 
-impl CryptoBackend for Crypto {
+impl CertificateBackend for Crypto {
     type Certificate = Certificate;
 
     fn from_pem(pem: &[u8]) -> Result<Self::Certificate> {
@@ -66,6 +67,16 @@ impl CryptoBackend for Crypto {
         cert.to_pem()
     }
 
+    fn get_public_key(cert: &Self::Certificate) -> Result<Vec<u8>> {
+        cert.public_key_spki_der()
+    }
+
+    fn get_extension_value_by_oid(cert: &Self::Certificate, oid: &str) -> Result<Option<Vec<u8>>> {
+        cert.get_extension_value_by_oid(oid)
+    }
+}
+
+impl CryptoBackend for Crypto {
     fn verify_chain(
         trusted_certs: &[&Certificate],
         untrusted_chain: &[&Certificate],
@@ -85,14 +96,6 @@ impl CryptoBackend for Crypto {
             prev = Some(cert);
         }
         Ok(())
-    }
-
-    fn get_public_key(cert: &Self::Certificate) -> Result<Vec<u8>> {
-        cert.public_key_spki_der()
-    }
-
-    fn get_extension_value_by_oid(cert: &Self::Certificate, oid: &str) -> Result<Option<Vec<u8>>> {
-        cert.get_extension_value_by_oid(oid)
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -3,7 +3,7 @@
 
 //! Cryptographic backend for certificate and attestation verification.
 //!
-//! Supports two backends via feature flags:
+//! Supports sync verification backends via feature flags:
 //! - `crypto_openssl` - OpenSSL-based (not available on WASM)
 //! - `crypto_pure_rust` - Pure Rust (required for WASM)
 //!
@@ -19,14 +19,18 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 use crate::snp::report::AttestationReport;
 
-/// Verifies that data was signed by the implementor's private key.
-pub trait Verifier<T> {
-    fn verify(&self, data: &T) -> Result<()>;
+pub mod verifier {
+    use super::Result;
+
+    /// Verifies that data was signed by the implementor's private key.
+    pub(crate) trait Sync<T> {
+        fn verify(&self, data: &T) -> Result<()>;
+    }
 }
 
-/// Crypto backend trait for certificate parsing and chain verification.
-pub trait CryptoBackend {
-    type Certificate: Verifier<Self::Certificate> + Verifier<AttestationReport>;
+/// Backend-internal trait for certificate parsing, encoding, and inspection.
+pub trait CertificateBackend {
+    type Certificate: Clone;
 
     /// Parse a certificate from PEM-encoded data.
     fn from_pem(pem: &[u8]) -> Result<Self::Certificate>;
@@ -43,13 +47,6 @@ pub trait CryptoBackend {
     /// Encode a certificate as PEM for debug logging.
     fn to_pem(cert: &Self::Certificate) -> Result<String>;
 
-    /// Verify a certificate chain from `trusted_certs` through `untrusted_chain` to `leaf`.
-    fn verify_chain(
-        trusted_certs: &[&Self::Certificate],
-        untrusted_chain: &[&Self::Certificate],
-        leaf: &Self::Certificate,
-    ) -> Result<()>;
-
     /// Extract the SubjectPublicKeyInfo (DER-encoded) from the certificate.
     fn get_public_key(cert: &Self::Certificate) -> Result<Vec<u8>>;
 
@@ -57,27 +54,42 @@ pub trait CryptoBackend {
     fn get_extension_value_by_oid(cert: &Self::Certificate, oid: &str) -> Result<Option<Vec<u8>>>;
 }
 
+/// Backend-internal trait for certificate verification operations.
+pub trait CryptoBackend: CertificateBackend
+where
+    <Self as CertificateBackend>::Certificate: verifier::Sync<<Self as CertificateBackend>::Certificate>
+        + verifier::Sync<AttestationReport>,
+{
+    /// Verify a certificate chain from `trusted_certs` through `untrusted_chain` to `leaf`.
+    fn verify_chain(
+        trusted_certs: &[&<Self as CertificateBackend>::Certificate],
+        untrusted_chain: &[&<Self as CertificateBackend>::Certificate],
+        leaf: &<Self as CertificateBackend>::Certificate,
+    ) -> Result<()>;
+}
+
 #[cfg(feature = "crypto_openssl")]
-mod crypto_openssl;
+pub(crate) mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
-mod crypto_pure_rust;
+pub(crate) mod crypto_pure_rust;
 #[cfg(feature = "crypto_pure_rust")]
 mod x509_certificate;
 
-// If both are enabled, prefer openssl
-#[cfg(feature = "crypto_openssl")]
-pub use crypto_openssl::Crypto;
-#[cfg(all(feature = "crypto_pure_rust", not(feature = "crypto_openssl")))]
-pub use crypto_pure_rust::Crypto;
+// If both are enabled, prefer pure rust
+#[cfg(all(feature = "crypto_openssl", not(feature = "crypto_pure_rust")))]
+pub type Crypto = crypto_openssl::Crypto;
+#[cfg(feature = "crypto_pure_rust")]
+pub type Crypto = crypto_pure_rust::Crypto;
 
 /// The certificate type for the active crypto backend.
-pub type Certificate = <Crypto as CryptoBackend>::Certificate;
+pub type Certificate = <Crypto as CertificateBackend>::Certificate;
 
 #[cfg(test)]
 mod test {
+    use super::verifier::Sync as Verifier;
     use zerocopy::{IntoBytes, TryFromBytes};
-    use Crypto;
 
+    use super::Crypto;
     use super::*;
 
     const MILAN_ARK: &[u8] = include_bytes!("test_data/milan_ark.pem");
@@ -92,24 +104,30 @@ mod test {
 
     #[test]
     fn full_chain_verifies() {
-        Crypto::verify_chain(&[&cert(MILAN_ARK)], &[&cert(MILAN_ASK)], &cert(MILAN_VCEK)).unwrap();
+        <Crypto as CryptoBackend>::verify_chain(
+            &[&cert(MILAN_ARK)],
+            &[&cert(MILAN_ASK)],
+            &cert(MILAN_VCEK),
+        )
+        .unwrap();
     }
 
     #[test]
     fn empty_trust_store_fails() {
-        Crypto::verify_chain(&[], &[], &cert(MILAN_VCEK))
+        <Crypto as CryptoBackend>::verify_chain(&[], &[], &cert(MILAN_VCEK))
             .expect_err("Should fail with no trusted certs");
     }
 
     #[test]
     fn untrusted_intermediates_are_required() {
-        Crypto::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_VCEK))
+        <Crypto as CryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_VCEK))
             .expect_err("VCEK should not verify without ASK intermediate");
     }
 
     #[test]
     fn self_signed_certificates() {
-        Crypto::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_ARK)).unwrap();
+        <Crypto as CryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_ARK))
+            .unwrap();
     }
 
     #[test]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -61,6 +61,8 @@ pub trait CryptoBackend {
 mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
 mod crypto_pure_rust;
+#[cfg(feature = "crypto_pure_rust")]
+mod x509_certificate;
 
 // If both are enabled, prefer openssl
 #[cfg(feature = "crypto_openssl")]
@@ -184,84 +186,5 @@ mod test {
 
         vcek.verify(&report)
             .expect_err("Wrong cert should not verify report");
-    }
-
-    #[test]
-    fn extension_lookup_returns_expected_bootloader_value() {
-        let vcek = cert(MILAN_VCEK);
-        let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
-        let tcb = report.reported_tcb.as_milan_genoa();
-
-        let bootloader = Crypto::get_extension_value_by_oid(&vcek, "1.3.6.1.4.1.3704.1.3.1")
-            .expect("BootLoader OID lookup should succeed")
-            .expect("BootLoader OID should be present in Milan VCEK");
-
-        assert_eq!(bootloader, vec![0x02, 0x01, tcb.boot_loader]);
-    }
-
-    #[test]
-    fn extension_lookup_returns_expected_hwid_value() {
-        let vcek = cert(MILAN_VCEK);
-        let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
-
-        let hwid = Crypto::get_extension_value_by_oid(&vcek, "1.3.6.1.4.1.3704.1.4")
-            .expect("HWID OID lookup should succeed")
-            .expect("HWID OID should be present in Milan VCEK");
-
-        assert_eq!(hwid, report.chip_id.as_slice());
-    }
-
-    #[test]
-    fn extension_lookup_returns_none_for_missing_oid() {
-        let vcek = cert(MILAN_VCEK);
-
-        let missing = Crypto::get_extension_value_by_oid(&vcek, "1.2.3.4.5.6.7.8.9")
-            .expect("Missing OID lookup should not fail");
-
-        assert!(missing.is_none());
-    }
-
-    #[test]
-    fn extension_lookup_rejects_malformed_oid() {
-        let vcek = cert(MILAN_VCEK);
-
-        Crypto::get_extension_value_by_oid(&vcek, "not-an-oid")
-            .expect_err("Malformed OID should fail");
-    }
-
-    #[test]
-    fn pem_chain_parsing_preserves_input_order() {
-        let mut pem_chain = Vec::new();
-        pem_chain.extend_from_slice(MILAN_ASK);
-        pem_chain.push(b'\n');
-        pem_chain.extend_from_slice(MILAN_ARK);
-
-        let chain = Crypto::from_pem_chain(&pem_chain).expect("PEM chain should parse");
-
-        assert_eq!(chain.len(), 2);
-        assert_eq!(
-            Crypto::to_der(&chain[0]).expect("ASK DER should encode"),
-            Crypto::to_der(&cert(MILAN_ASK)).expect("ASK fixture DER should encode")
-        );
-        assert_eq!(
-            Crypto::to_der(&chain[1]).expect("ARK DER should encode"),
-            Crypto::to_der(&cert(MILAN_ARK)).expect("ARK fixture DER should encode")
-        );
-    }
-
-    #[test]
-    fn pem_encoding_round_trips_through_from_pem() {
-        let cert = cert(MILAN_VCEK);
-        let pem = Crypto::to_pem(&cert).expect("PEM encoding should succeed");
-        let reparsed = Crypto::from_pem(pem.as_bytes()).expect("PEM should parse");
-
-        assert_eq!(
-            Crypto::to_der(&reparsed).expect("Reparsed DER should encode"),
-            Crypto::to_der(&cert).expect("Original DER should encode")
-        );
     }
 }

--- a/src/crypto/x509_certificate.rs
+++ b/src/crypto/x509_certificate.rs
@@ -1,0 +1,245 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use x509_cert::der::{
+    oid::ObjectIdentifier, pem::LineEnding, referenced::OwnedToRef, Decode, DecodePem, Encode,
+    EncodePem,
+};
+use x509_cert::spki::AlgorithmIdentifierOwned;
+
+use super::Result;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Certificate {
+    inner: x509_cert::Certificate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SignatureAlgorithm {
+    RsaPss,
+}
+
+impl Certificate {
+    pub fn from_pem(pem: &[u8]) -> Result<Self> {
+        Ok(Self {
+            inner: x509_cert::Certificate::from_pem(pem)?,
+        })
+    }
+
+    pub fn from_pem_chain(pem: &[u8]) -> Result<Vec<Self>> {
+        x509_cert::Certificate::load_pem_chain(pem)?
+            .into_iter()
+            .map(|inner| Ok(Self { inner }))
+            .collect()
+    }
+
+    pub fn from_der(der: &[u8]) -> Result<Self> {
+        Ok(Self {
+            inner: x509_cert::Certificate::from_der(der)?,
+        })
+    }
+
+    pub fn to_der(&self) -> Result<Vec<u8>> {
+        Ok(self.inner.to_der()?)
+    }
+
+    pub fn to_pem(&self) -> Result<String> {
+        Ok(self.inner.to_pem(LineEnding::LF)?)
+    }
+
+    pub fn public_key_spki_der(&self) -> Result<Vec<u8>> {
+        Ok(self
+            .inner
+            .tbs_certificate
+            .subject_public_key_info
+            .to_der()?)
+    }
+
+    pub fn get_extension_value_by_oid(&self, oid: &str) -> Result<Option<Vec<u8>>> {
+        let oid = ObjectIdentifier::new(oid)?;
+
+        let extensions = match self.inner.tbs_certificate.extensions.as_ref() {
+            Some(extensions) => extensions,
+            None => return Ok(None),
+        };
+
+        Ok(extensions
+            .iter()
+            .find(|extension| extension.extn_id == oid)
+            .map(|extension| extension.extn_value.as_bytes().to_vec()))
+    }
+
+    pub fn tbs_certificate_der(&self) -> Result<Vec<u8>> {
+        Ok(self.inner.tbs_certificate.to_der()?)
+    }
+
+    pub fn signature_bytes(&self) -> &[u8] {
+        self.inner.signature.raw_bytes()
+    }
+
+    pub fn signature_algorithm(&self) -> Result<SignatureAlgorithm> {
+        parse_signature_algorithm(&self.inner.signature_algorithm)
+    }
+
+    pub fn subject_public_key_bytes(&self) -> &[u8] {
+        self.inner
+            .tbs_certificate
+            .subject_public_key_info
+            .subject_public_key
+            .raw_bytes()
+    }
+}
+
+fn parse_signature_algorithm(algorithm: &AlgorithmIdentifierOwned) -> Result<SignatureAlgorithm> {
+    let algorithm_ref = algorithm.owned_to_ref();
+
+    if algorithm_ref.oid == oid::RSA_PSS {
+        return Ok(SignatureAlgorithm::RsaPss);
+    }
+
+    Err(format!("Unsupported signature algorithm OID: {}", algorithm_ref.oid).into())
+}
+
+mod oid {
+    use x509_cert::der::oid::ObjectIdentifier;
+
+    pub const RSA_PSS: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.113549.1.1.10");
+}
+
+#[cfg(test)]
+mod test {
+    use x509_cert::der::Encode;
+    use zerocopy::TryFromBytes;
+
+    use super::{Certificate, SignatureAlgorithm};
+
+    const MILAN_ARK: &[u8] = include_bytes!("test_data/milan_ark.pem");
+    const MILAN_ASK: &[u8] = include_bytes!("test_data/milan_ask.pem");
+    const MILAN_VCEK: &[u8] = include_bytes!("test_data/milan_vcek.pem");
+    const MILAN_REPORT: &[u8] = include_bytes!("test_data/milan_attestation_report.bin");
+
+    fn cert(pem: &[u8]) -> Certificate {
+        Certificate::from_pem(pem).unwrap()
+    }
+
+    #[test]
+    fn from_der_round_trips_from_pem_certificate() {
+        let cert = cert(MILAN_VCEK);
+        let der = cert.to_der().expect("DER encoding should succeed");
+        let reparsed = Certificate::from_der(&der).expect("DER should parse");
+
+        assert_eq!(reparsed.to_der().expect("Reparsed DER should encode"), der);
+    }
+
+    #[test]
+    fn get_public_key_returns_subject_public_key_info_der() {
+        let cert = cert(MILAN_ARK);
+
+        assert_eq!(
+            cert.public_key_spki_der()
+                .expect("SPKI extraction should succeed"),
+            cert.inner
+                .tbs_certificate
+                .subject_public_key_info
+                .to_der()
+                .expect("SPKI DER should encode")
+        );
+    }
+
+    #[test]
+    fn extension_lookup_returns_expected_bootloader_value() {
+        let vcek = cert(MILAN_VCEK);
+        let report = crate::AttestationReport::try_read_from_bytes(MILAN_REPORT)
+            .expect("Failed to parse attestation report")
+            .clone();
+        let tcb = report.reported_tcb.as_milan_genoa();
+
+        let bootloader = vcek
+            .get_extension_value_by_oid("1.3.6.1.4.1.3704.1.3.1")
+            .expect("BootLoader OID lookup should succeed")
+            .expect("BootLoader OID should be present in Milan VCEK");
+
+        assert_eq!(bootloader, vec![0x02, 0x01, tcb.boot_loader]);
+    }
+
+    #[test]
+    fn extension_lookup_returns_expected_hwid_value() {
+        let vcek = cert(MILAN_VCEK);
+        let report = crate::AttestationReport::try_read_from_bytes(MILAN_REPORT)
+            .expect("Failed to parse attestation report")
+            .clone();
+
+        let hwid = vcek
+            .get_extension_value_by_oid("1.3.6.1.4.1.3704.1.4")
+            .expect("HWID OID lookup should succeed")
+            .expect("HWID OID should be present in Milan VCEK");
+
+        assert_eq!(hwid, report.chip_id.as_slice());
+    }
+
+    #[test]
+    fn extension_lookup_returns_none_for_missing_oid() {
+        let vcek = cert(MILAN_VCEK);
+
+        let missing = vcek
+            .get_extension_value_by_oid("1.2.3.4.5.6.7.8.9")
+            .expect("Missing OID lookup should not fail");
+
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn extension_lookup_rejects_malformed_oid() {
+        let vcek = cert(MILAN_VCEK);
+
+        vcek.get_extension_value_by_oid("not-an-oid")
+            .expect_err("Malformed OID should fail");
+    }
+
+    #[test]
+    fn pem_chain_parsing_preserves_input_order() {
+        let mut pem_chain = Vec::new();
+        pem_chain.extend_from_slice(MILAN_ASK);
+        pem_chain.push(b'\n');
+        pem_chain.extend_from_slice(MILAN_ARK);
+
+        let chain = Certificate::from_pem_chain(&pem_chain).expect("PEM chain should parse");
+
+        assert_eq!(chain.len(), 2);
+        assert_eq!(
+            chain[0].to_der().expect("ASK DER should encode"),
+            cert(MILAN_ASK)
+                .to_der()
+                .expect("ASK fixture DER should encode")
+        );
+        assert_eq!(
+            chain[1].to_der().expect("ARK DER should encode"),
+            cert(MILAN_ARK)
+                .to_der()
+                .expect("ARK fixture DER should encode")
+        );
+    }
+
+    #[test]
+    fn pem_encoding_round_trips_through_from_pem() {
+        let cert = cert(MILAN_VCEK);
+        let pem = cert.to_pem().expect("PEM encoding should succeed");
+        let reparsed = Certificate::from_pem(pem.as_bytes()).expect("PEM should parse");
+
+        assert_eq!(
+            reparsed.to_der().expect("Reparsed DER should encode"),
+            cert.to_der().expect("Original DER should encode")
+        );
+    }
+
+    #[test]
+    fn signature_algorithm_reports_rsa_pss() {
+        let cert = cert(MILAN_VCEK);
+
+        assert_eq!(
+            cert.signature_algorithm()
+                .expect("Signature algorithm should parse"),
+            SignatureAlgorithm::RsaPss
+        );
+    }
+}

--- a/src/kds.rs
+++ b/src/kds.rs
@@ -4,7 +4,7 @@
 #[cfg(not(any(feature = "online", target_arch = "wasm32")))]
 compile_error!("kds module requires either the 'online' feature or wasm32 target");
 
-use crate::crypto::{Certificate, Crypto, CryptoBackend};
+use crate::crypto::{Certificate, CertificateBackend, Crypto};
 use crate::snp;
 use crate::{certificate_chain::CertificateFetcher, AttestationReport};
 #[cfg(target_arch = "wasm32")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod pinned_arks;
 pub mod snp;
 pub mod utils;
 
-use crypto::{Crypto, CryptoBackend};
+use crypto::{CertificateBackend, Crypto};
 
 pub use crypto::Certificate;
 pub use snp::report::AttestationReport;

--- a/src/pinned_arks/mod.rs
+++ b/src/pinned_arks/mod.rs
@@ -6,7 +6,7 @@
 //! These certificates are embedded at compile time and used for offline verification
 //! without requiring network access to AMD's KDS.
 
-use crate::crypto::{Certificate, Crypto, CryptoBackend};
+use crate::crypto::{Certificate, CertificateBackend, Crypto};
 use crate::snp::model::Generation;
 
 const MILAN_ARK_PEM: &[u8] = include_bytes!("milan_ark.pem");

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::crypto::{Certificate, Crypto, CryptoBackend, Verifier};
+use crate::crypto::verifier::Sync as Verifier;
+use crate::crypto::{Certificate, CertificateBackend, Crypto, CryptoBackend};
 use crate::{snp, snp::utils::Oid, AttestationReport};
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR pulls the x509_certificate dependency out of crypto_pure_rust. This makes the use of x509_certificate explicit as a 'parsing only' dependency.

Also splits the CryptoBackend trait into a CertificateBackend and CryptoBackend. This paves the way for adding the AsyncCryptoBackend in #25.

Depends on #23 (review from 5f12133 onwards)