### PR TITLE
Sync and async verifier

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,12 @@
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(sync_crypto)");
     println!("cargo:rustc-check-cfg=cfg(async_crypto)");
-    println!("cargo:rustc-check-cfg=cfg(crypto_provider, values(\"crypto_openssl\", \"crypto_pure_rust\"))");
+    println!("cargo:rustc-check-cfg=cfg(crypto_backend, values(\"crypto_openssl\", \"crypto_pure_rust\"))");
 
     let has_openssl = std::env::var_os("CARGO_FEATURE_CRYPTO_OPENSSL").is_some();
     let has_pure_rust = std::env::var_os("CARGO_FEATURE_CRYPTO_PURE_RUST").is_some();
 
-    let crypto_provider = if has_pure_rust {
+    let crypto_backend = if has_pure_rust {
         Some("crypto_pure_rust")
     } else if has_openssl {
         Some("crypto_openssl")
@@ -14,9 +14,9 @@ fn main() {
         None
     };
 
-    if let Some(crypto_provider) = crypto_provider {
+    if let Some(crypto_backend) = crypto_backend {
         println!("cargo:rustc-cfg=sync_crypto");
         println!("cargo:rustc-cfg=async_crypto");
-        println!("cargo:rustc-cfg=crypto_provider=\"{crypto_provider}\"");
+        println!("cargo:rustc-cfg=crypto_backend=\"{crypto_backend}\"");
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,15 @@
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(sync_crypto)");
     println!("cargo:rustc-check-cfg=cfg(async_crypto)");
-    println!("cargo:rustc-check-cfg=cfg(crypto_provider, values(\"openssl\", \"pure_rust\"))");
+    println!("cargo:rustc-check-cfg=cfg(crypto_provider, values(\"crypto_openssl\", \"crypto_pure_rust\"))");
 
     let has_openssl = std::env::var_os("CARGO_FEATURE_CRYPTO_OPENSSL").is_some();
     let has_pure_rust = std::env::var_os("CARGO_FEATURE_CRYPTO_PURE_RUST").is_some();
 
     let crypto_provider = if has_pure_rust {
-        Some("pure_rust")
+        Some("crypto_pure_rust")
     } else if has_openssl {
-        Some("openssl")
+        Some("crypto_openssl")
     } else {
         None
     };

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(sync_crypto)");
+    println!("cargo:rustc-check-cfg=cfg(async_crypto)");
+    println!("cargo:rustc-check-cfg=cfg(crypto_provider, values(\"openssl\", \"pure_rust\"))");
+
+    let has_openssl = std::env::var_os("CARGO_FEATURE_CRYPTO_OPENSSL").is_some();
+    let has_pure_rust = std::env::var_os("CARGO_FEATURE_CRYPTO_PURE_RUST").is_some();
+
+    let crypto_provider = if has_pure_rust {
+        Some("pure_rust")
+    } else if has_openssl {
+        Some("openssl")
+    } else {
+        None
+    };
+
+    if let Some(crypto_provider) = crypto_provider {
+        println!("cargo:rustc-cfg=sync_crypto");
+        println!("cargo:rustc-cfg=async_crypto");
+        println!("cargo:rustc-cfg=crypto_provider=\"{crypto_provider}\"");
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -123,7 +123,7 @@ where
 pub(crate) mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
 pub(crate) mod crypto_pure_rust;
-#[cfg(crypto_backend = "crypto_pure_rust")]
+#[cfg(feature = "crypto_pure_rust")]
 mod x509_certificate;
 
 #[cfg(crypto_backend = "crypto_openssl")]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -123,12 +123,12 @@ where
 pub(crate) mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
 pub(crate) mod crypto_pure_rust;
-#[cfg(crypto_provider = "pure_rust")]
+#[cfg(crypto_provider = "crypto_pure_rust")]
 mod x509_certificate;
 
-#[cfg(crypto_provider = "openssl")]
+#[cfg(crypto_provider = "crypto_openssl")]
 pub type Crypto = crypto_openssl::Crypto;
-#[cfg(crypto_provider = "pure_rust")]
+#[cfg(crypto_provider = "crypto_pure_rust")]
 pub type Crypto = crypto_pure_rust::Crypto;
 
 /// The certificate type for the active crypto backend.

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -123,12 +123,12 @@ where
 pub(crate) mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
 pub(crate) mod crypto_pure_rust;
-#[cfg(crypto_provider = "crypto_pure_rust")]
+#[cfg(crypto_backend = "crypto_pure_rust")]
 mod x509_certificate;
 
-#[cfg(crypto_provider = "crypto_openssl")]
+#[cfg(crypto_backend = "crypto_openssl")]
 pub type Crypto = crypto_openssl::Crypto;
-#[cfg(crypto_provider = "crypto_pure_rust")]
+#[cfg(crypto_backend = "crypto_pure_rust")]
 pub type Crypto = crypto_pure_rust::Crypto;
 
 /// The certificate type for the active crypto backend.

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -9,7 +9,7 @@
 //!
 //! If both are enabled, `crypto_openssl` takes precedence.
 
-#[cfg(not(any(feature = "crypto_openssl", feature = "crypto_pure_rust")))]
+#[cfg(not(sync_crypto))]
 compile_error!("Either `crypto_openssl` or `crypto_pure_rust` feature must be enabled.");
 #[cfg(all(target_arch = "wasm32", feature = "crypto_openssl"))]
 compile_error!(
@@ -25,6 +25,20 @@ pub mod verifier {
     /// Verifies that data was signed by the implementor's private key.
     pub(crate) trait Sync<T> {
         fn verify(&self, data: &T) -> Result<()>;
+    }
+
+    /// Asynchronously verifies that data was signed by the implementor's private key.
+    pub(crate) trait Async<T> {
+        fn verify(&self, data: &T) -> impl std::future::Future<Output = Result<()>>;
+    }
+
+    impl<V, T> Async<T> for V
+    where
+        V: Sync<T>,
+    {
+        fn verify(&self, data: &T) -> impl std::future::Future<Output = Result<()>> {
+            std::future::ready(Sync::verify(self, data))
+        }
     }
 }
 
@@ -68,17 +82,53 @@ where
     ) -> Result<()>;
 }
 
+/// Backend-internal trait for asynchronous certificate verification operations.
+pub(crate) trait AsyncCryptoBackend {
+    type Certificate: Clone
+        + verifier::Async<Self::Certificate>
+        + verifier::Async<AttestationReport>;
+
+    /// Verify a certificate chain from `trusted_certs` through `untrusted_chain` to `leaf`.
+    fn verify_chain(
+        trusted_certs: &[&Self::Certificate],
+        untrusted_chain: &[&Self::Certificate],
+        leaf: &Self::Certificate,
+    ) -> impl std::future::Future<Output = Result<()>>;
+}
+
+impl<C> AsyncCryptoBackend for C
+where
+    C: CryptoBackend,
+    <C as CertificateBackend>::Certificate: verifier::Sync<<C as CertificateBackend>::Certificate>
+        + verifier::Sync<AttestationReport>
+        + verifier::Async<<C as CertificateBackend>::Certificate>
+        + verifier::Async<AttestationReport>,
+{
+    type Certificate = <C as CertificateBackend>::Certificate;
+
+    fn verify_chain(
+        trusted_certs: &[&Self::Certificate],
+        untrusted_chain: &[&Self::Certificate],
+        leaf: &Self::Certificate,
+    ) -> impl std::future::Future<Output = Result<()>> {
+        std::future::ready(<C as CryptoBackend>::verify_chain(
+            trusted_certs,
+            untrusted_chain,
+            leaf,
+        ))
+    }
+}
+
 #[cfg(feature = "crypto_openssl")]
 pub(crate) mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
 pub(crate) mod crypto_pure_rust;
-#[cfg(feature = "crypto_pure_rust")]
+#[cfg(crypto_provider = "pure_rust")]
 mod x509_certificate;
 
-// If both are enabled, prefer pure rust
-#[cfg(all(feature = "crypto_openssl", not(feature = "crypto_pure_rust")))]
+#[cfg(crypto_provider = "openssl")]
 pub type Crypto = crypto_openssl::Crypto;
-#[cfg(feature = "crypto_pure_rust")]
+#[cfg(crypto_provider = "pure_rust")]
 pub type Crypto = crypto_pure_rust::Crypto;
 
 /// The certificate type for the active crypto backend.

--- a/src/sev_verification.rs
+++ b/src/sev_verification.rs
@@ -72,7 +72,7 @@ impl SevVerifier {
         snp::verify::asynchronous::verify_attestation(
             attestation_report,
             vcek,
-            snp::verify::ChainVerification::Skip,
+            &snp::verify::ChainVerification::Skip,
         )
         .await
     }

--- a/src/sev_verification.rs
+++ b/src/sev_verification.rs
@@ -69,10 +69,11 @@ impl SevVerifier {
 
         // Step 3: Verify signature and TCB
         // Skip redundant certificate chain verification since we already verified the VCEK chain
-        snp::verify::verify_attestation(
+        snp::verify::asynchronous::verify_attestation(
             attestation_report,
             vcek,
             snp::verify::ChainVerification::Skip,
         )
+        .await
     }
 }

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::crypto::verifier::Sync as Verifier;
-use crate::crypto::{Certificate, CertificateBackend, Crypto, CryptoBackend};
+use crate::crypto::{Certificate, CertificateBackend, Crypto};
 use crate::{snp, snp::utils::Oid, AttestationReport};
 
 #[derive(Debug)]
@@ -28,6 +27,9 @@ impl std::fmt::Display for VerificationError {
 
 impl std::error::Error for VerificationError {}
 
+//ChainVerification::Skip skips chain verification and only verifies report signature + TCB using VCEK.
+//ChainVerification::WithPinnedArk verifies chain with pinned ARK for the processor model.
+//ChainVerification::WithProvidedArk verifies chain with caller-provided ARK after validating its public key matches pinned ARK.
 pub enum ChainVerification<'a> {
     Skip,
     WithPinnedArk {
@@ -39,53 +41,99 @@ pub enum ChainVerification<'a> {
     },
 }
 
-// Verifies the attestation report using the provided ARK, ASK, and VCEK certificates.
-// If verification is successful, returns Ok(()). Otherwise, returns a VerificationError with details of the step which failed.
-// - Use ChainVerification::Skip to skip chain verification and only verify report signature + TCB using VCEK.
-// - Use ChainVerification::WithPinnedArk to verify chain with pinned ARK for the processor model.
-// - Use ChainVerification::WithProvidedArk to verify chain with caller-provided ARK after validating its public key matches pinned ARK.
-pub fn verify_attestation(
-    attestation_report: &AttestationReport,
-    vcek: &Certificate,
-    chain_verification: ChainVerification<'_>,
-) -> Result<(), VerificationError> {
-    let generation = snp::model::Generation::from_family_and_model(
-        attestation_report.cpuid_fam_id,
-        attestation_report.cpuid_mod_id,
-    )
-    .map_err(|e| VerificationError::UnsupportedProcessor(format!("{:?}", e)))?;
+#[cfg(sync_crypto)]
+pub mod sync {
+    use crate::crypto::verifier::Sync as Verifier;
+    use crate::crypto::{Certificate, Crypto, CryptoBackend};
+    use crate::{snp, AttestationReport};
 
-    match chain_verification {
-        ChainVerification::WithProvidedArk { ask, ark } => {
-            // If ARK is provided, verify it matches the pinned ARK for this generation
-            ark_matches_pinned(generation, ark)
-                .map_err(|e| VerificationError::InvalidRootCertificate(format!("{:?}", e)))?;
+    use super::{ark_matches_pinned, verify_tcb_values, ChainVerification, VerificationError};
 
-            // Verify the certificate chain: ARK -> ASK -> VCEK
-            Crypto::verify_chain(&[ark], &[ask], vcek)
-                .map_err(|e| VerificationError::CertificateChainError(format!("{:?}", e)))?;
-        }
-        ChainVerification::WithPinnedArk { ask } => {
-            // No ARK provided, use pinned ARK for chain verification
-            let pinned_ark = crate::pinned_arks::get_ark(generation)
-                .map_err(|e| VerificationError::InvalidRootCertificate(format!("{:?}", e)))?;
-            Crypto::verify_chain(&[&pinned_ark], &[ask], vcek)
-                .map_err(|e| VerificationError::CertificateChainError(format!("{:?}", e)))?;
-        }
-        ChainVerification::Skip => {
-            // No ASK provided, skip chain verification
-        }
-    };
+    pub fn verify_attestation(
+        attestation_report: &AttestationReport,
+        vcek: &Certificate,
+        chain_verification: ChainVerification<'_>,
+    ) -> Result<(), VerificationError> {
+        let generation = snp::model::Generation::from_family_and_model(
+            attestation_report.cpuid_fam_id,
+            attestation_report.cpuid_mod_id,
+        )
+        .map_err(|e| VerificationError::UnsupportedProcessor(format!("{:?}", e)))?;
 
-    // Verify the attestation report signature using the VCEK
-    vcek.verify(attestation_report)
-        .map_err(|e| VerificationError::SignatureVerificationError(format!("{:?}", e)))?;
+        match chain_verification {
+            ChainVerification::WithProvidedArk { ask, ark } => {
+                ark_matches_pinned(generation, ark)
+                    .map_err(|e| VerificationError::InvalidRootCertificate(format!("{:?}", e)))?;
 
-    // Verify that the TCB values in the VCEK match those reported in the attestation report
-    verify_tcb_values(vcek, attestation_report)
-        .map_err(|e| VerificationError::TcbVerificationError(format!("{:?}", e)))?;
+                Crypto::verify_chain(&[ark], &[ask], vcek)
+                    .map_err(|e| VerificationError::CertificateChainError(format!("{:?}", e)))?;
+            }
+            ChainVerification::WithPinnedArk { ask } => {
+                let pinned_ark = crate::pinned_arks::get_ark(generation)
+                    .map_err(|e| VerificationError::InvalidRootCertificate(format!("{:?}", e)))?;
+                Crypto::verify_chain(&[&pinned_ark], &[ask], vcek)
+                    .map_err(|e| VerificationError::CertificateChainError(format!("{:?}", e)))?;
+            }
+            ChainVerification::Skip => {}
+        };
 
-    Ok(())
+        vcek.verify(attestation_report)
+            .map_err(|e| VerificationError::SignatureVerificationError(format!("{:?}", e)))?;
+
+        verify_tcb_values(vcek, attestation_report)
+            .map_err(|e| VerificationError::TcbVerificationError(format!("{:?}", e)))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(async_crypto)]
+pub mod asynchronous {
+    use crate::crypto::verifier::Async as Verifier;
+    use crate::crypto::{Crypto, AsyncCryptoBackend, Certificate};
+    use crate::{snp, AttestationReport};
+
+    use super::{ark_matches_pinned, verify_tcb_values, ChainVerification, VerificationError};
+
+    pub async fn verify_attestation(
+        attestation_report: &AttestationReport,
+        vcek: &Certificate,
+        chain_verification: ChainVerification<'_>,
+    ) -> Result<(), VerificationError> {
+        let generation = snp::model::Generation::from_family_and_model(
+            attestation_report.cpuid_fam_id,
+            attestation_report.cpuid_mod_id,
+        )
+        .map_err(|e| VerificationError::UnsupportedProcessor(format!("{:?}", e)))?;
+
+        match chain_verification {
+            ChainVerification::WithProvidedArk { ask, ark } => {
+                ark_matches_pinned(generation, ark)
+                    .map_err(|e| VerificationError::InvalidRootCertificate(format!("{:?}", e)))?;
+
+                Crypto::verify_chain(&[ark], &[ask], vcek)
+                    .await
+                    .map_err(|e| VerificationError::CertificateChainError(format!("{:?}", e)))?;
+            }
+            ChainVerification::WithPinnedArk { ask } => {
+                let pinned_ark = crate::pinned_arks::get_ark(generation)
+                    .map_err(|e| VerificationError::InvalidRootCertificate(format!("{:?}", e)))?;
+                Crypto::verify_chain(&[&pinned_ark], &[ask], vcek)
+                    .await
+                    .map_err(|e| VerificationError::CertificateChainError(format!("{:?}", e)))?;
+            }
+            ChainVerification::Skip => {}
+        };
+
+        vcek.verify(attestation_report)
+            .await
+            .map_err(|e| VerificationError::SignatureVerificationError(format!("{:?}", e)))?;
+
+        verify_tcb_values(vcek, attestation_report)
+            .map_err(|e| VerificationError::TcbVerificationError(format!("{:?}", e)))?;
+
+        Ok(())
+    }
 }
 
 pub(crate) fn ark_matches_pinned(

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -52,7 +52,7 @@ pub mod sync {
     pub fn verify_attestation(
         attestation_report: &AttestationReport,
         vcek: &Certificate,
-        chain_verification: ChainVerification<'_>,
+        chain_verification: &ChainVerification<'_>,
     ) -> Result<(), VerificationError> {
         let generation = snp::model::Generation::from_family_and_model(
             attestation_report.cpuid_fam_id,
@@ -90,7 +90,7 @@ pub mod sync {
 #[cfg(async_crypto)]
 pub mod asynchronous {
     use crate::crypto::verifier::Async as Verifier;
-    use crate::crypto::{Crypto, AsyncCryptoBackend, Certificate};
+    use crate::crypto::{AsyncCryptoBackend, Certificate, Crypto};
     use crate::{snp, AttestationReport};
 
     use super::{ark_matches_pinned, verify_tcb_values, ChainVerification, VerificationError};
@@ -98,7 +98,7 @@ pub mod asynchronous {
     pub async fn verify_attestation(
         attestation_report: &AttestationReport,
         vcek: &Certificate,
-        chain_verification: ChainVerification<'_>,
+        chain_verification: &ChainVerification<'_>,
     ) -> Result<(), VerificationError> {
         let generation = snp::model::Generation::from_family_and_model(
             attestation_report.cpuid_fam_id,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -22,6 +22,7 @@ pub const MILAN_VCEK: &[u8] = include_bytes!("test_data/milan_vcek.pem");
 pub const GENOA_VCEK: &[u8] = include_bytes!("test_data/genoa_vcek.pem");
 pub const TURIN_VCEK: &[u8] = include_bytes!("test_data/turin_vcek.pem");
 
+#[cfg(sync_crypto)]
 pub fn test_verify_attestation_suite() {
     let tampered_milan_attestation = {
         let mut tampered = MILAN_ATTESTATION.to_vec();
@@ -84,7 +85,7 @@ pub fn test_verify_attestation_suite() {
     for (tag, att, vcek, chain, expected) in tests {
         let report = AttestationReport::read_from_bytes(att).unwrap();
         let vcek = certificate_from_pem(vcek).unwrap();
-        let result = verify::sync::verify_attestation(&report, &vcek, chain);
+        let result = verify::sync::verify_attestation(&report, &vcek, &chain);
 
         if let Err(e_str) = expected {
             let err = result.expect_err(&format!("{}: Expected to fail with {}", tag, e_str));
@@ -101,7 +102,7 @@ pub fn test_verify_attestation_suite() {
     }
 }
 
-#[cfg(any(target_family = "wasm", feature = "online"))]
+#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
 pub async fn verify_attestation_bytes(bytes: &[u8]) -> Result<(), String> {
     let attestation_report = AttestationReport::read_from_bytes(bytes)
         .map_err(|e| format!("Failed to read attestation report: {:?}", e))?;
@@ -116,17 +117,17 @@ pub async fn verify_attestation_bytes(bytes: &[u8]) -> Result<(), String> {
         .map_err(|e| format!("Verification call failed: {:?}", e))
 }
 
-#[cfg(any(target_family = "wasm", feature = "online"))]
+#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
 pub async fn verify_milan_attestation() -> Result<(), String> {
     verify_attestation_bytes(MILAN_ATTESTATION).await
 }
 
-#[cfg(any(target_family = "wasm", feature = "online"))]
+#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
 pub async fn verify_genoa_attestation() -> Result<(), String> {
     verify_attestation_bytes(GENOA_ATTESTATION).await
 }
 
-#[cfg(any(target_family = "wasm", feature = "online"))]
+#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
 pub async fn verify_turin_attestation() -> Result<(), String> {
     verify_attestation_bytes(TURIN_ATTESTATION).await
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -84,7 +84,7 @@ pub fn test_verify_attestation_suite() {
     for (tag, att, vcek, chain, expected) in tests {
         let report = AttestationReport::read_from_bytes(att).unwrap();
         let vcek = certificate_from_pem(vcek).unwrap();
-        let result = verify::verify_attestation(&report, &vcek, chain);
+        let result = verify::sync::verify_attestation(&report, &vcek, chain);
 
         if let Err(e_str) = expected {
             let err = result.expect_err(&format!("{}: Expected to fail with {}", tag, e_str));

--- a/tests/tests_native.rs
+++ b/tests/tests_native.rs
@@ -47,6 +47,7 @@ mod online {
 }
 
 /// Offline verification tests (sync, uses pinned ARKs)
+#[cfg(sync_crypto)]
 mod offline {
     use super::*;
 

--- a/tests/tests_node.rs
+++ b/tests/tests_node.rs
@@ -54,6 +54,7 @@ mod online {
 }
 
 /// Offline verification tests (sync, uses pinned ARKs)
+#[cfg(sync_crypto)]
 mod offline {
     use super::*;
 


### PR DESCRIPTION
In preparation of WebCrypto backend, we need to have an async crypto backend.

An async-only backend poses a 'coloured function' problem to current sync users.
Specifically we need to expose this in a reasonable manner and also have sufficient gating that users can use either interface depending on what backend they choose to compile against.

I've added a build.rs to manage the choosing of which crypto backend we use, exposing the `sync_crypto`, `async_crypto` and `crypto_provider`, and hopefully reducing the amount of feature soup.

This depends on both #23 and #24 (review from ebad725)