### PR TITLE
Webcrypto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           cargo install wasm-bindgen-cli
           cargo install wasm-pack
 
+      - name: Build WASM with WebCrypto crypto
+        run: wasm-pack build --target web --no-default-features --features "crypto_webcrypto"
+
       - name: Test WASM offline
         run: wasm-pack test --node --no-default-features --features "crypto_pure_rust" -- offline
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,14 @@ jobs:
         run: wasm-pack build --target web --no-default-features --features "crypto_webcrypto"
 
       - name: Test WASM offline
-        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust" -- offline
+        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust"
 
       - name: Test WASM offline with WebCrypto backend
-        run: wasm-pack test --node --no-default-features --features "crypto_webcrypto" -- offline_async
+        run: wasm-pack test --node --no-default-features --features "crypto_webcrypto"
 
       - name: Test WASM online (optional - may fail due to KDS rate limiting)
         continue-on-error: true
-        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust,serde"
+        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust,serde,online"
 
   native-openssl:
     name: Native openssl
@@ -74,7 +74,7 @@ jobs:
 
       - name: Test online with openssl (optional - may fail due to KDS rate limiting)
         continue-on-error: true
-        run: cargo test --no-default-features --features "crypto_openssl,online" online -- --nocapture
+        run: cargo test --no-default-features --features "crypto_openssl,online" -- --nocapture
 
   native-pure-rust:
     name: Native pure-rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,11 @@ jobs:
           cargo install wasm-bindgen-cli
           cargo install wasm-pack
 
-      - name: Build WASM
-        run: |
-          cargo build --target wasm32-unknown-unknown --no-default-features --features "crypto_pure_rust,serde"
-          wasm-pack build --no-default-features --features "crypto_pure_rust,serde"
-
-
       - name: Test WASM offline
-        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust,serde" -- offline
+        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust" -- offline
+
+      - name: Test WASM offline with WebCrypto backend
+        run: wasm-pack test --node --no-default-features --features "crypto_webcrypto" -- offline_async
 
       - name: Test WASM online (optional - may fail due to KDS rate limiting)
         continue-on-error: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "rust-analyzer.cargo.features": [
+    "crypto_pure_rust", "crypto_openssl"
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 # At least one crypto backend must be enabled.
 crypto_openssl = ["dep:foreign-types", "dep:openssl", "dep:openssl-sys"]
 crypto_pure_rust = ["dep:ecdsa", "dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
+crypto_webcrypto = ["dep:x509-cert"]
 serde = ["dep:serde", "dep:serde-big-array", "dep:serde_json"]
 online = ["dep:curl", "dep:tokio"]
 
@@ -29,6 +30,9 @@ required-features = ["online"]
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 env_logger = "0.11"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
 # Crypto

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [features]
-default = ["crypto_openssl"]
-# If both enabled, defaults to crypto_pure_rust but expose the crypto_openssl module
+# At least one crypto backend must be enabled.
 crypto_openssl = ["dep:foreign-types", "dep:openssl", "dep:openssl-sys"]
 crypto_pure_rust = ["dep:ecdsa", "dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 serde = ["dep:serde", "dep:serde-big-array", "dep:serde_json"]

--- a/README.md
+++ b/README.md
@@ -5,34 +5,48 @@ A minimal-external-dependencies, portable and safe library for verifying a TEE a
 ## Features
 
 - **AMD SEV-SNP Attestation Verification**: Validates attestation reports from AMD EPYC processors
-- **WASM-Compatible**: Built for `wasm32-unknown-unknown` target with no external dependencies
-- **Azure Linux 3.0 compatible**: Built for Azure Linux 3.0, with `rust-openssl` as the sole dependency.
+- **WASM-Compatible**: Build for `wasm32` with a WebCrypto backend
+- **Azure Linux 3.0 compatible**: Build for Azure Linux 3.0, with `rust-openssl` as the sole dependency.
 
 ## Usage
 
-```rust
-use sev_verification::verify_attestation;
+Add the library to your `Cargo.toml` with a native crypto backend:
 
-let result = verify_attestation(attestation_bytes).await?;
-
-if result.is_valid {
-    println!("Attestation verified successfully!");
-} else {
-    println!("Verification failed: {:?}", result.errors);
-}
+```toml
+[dependencies]
+tee-attestation-verification-lib = { version = "0.1.0", features = ["crypto_openssl"] }
 ```
 
-## Building
+Then verify an attestation report with the synchronous `snp::verify::sync` API:
 
-Build for WebAssembly:
+```rust
+use tee_attestation_verification_lib::snp::verify::{sync, ChainVerification};
+use tee_attestation_verification_lib::{certificate_from_pem, AttestationReport};
+use zerocopy::FromBytes;
+
+let attestation_report = AttestationReport::read_from_bytes(attestation_bytes)?;
+let vcek = certificate_from_pem(vcek_pem)?;
+let ask = certificate_from_pem(ask_pem)?;
+
+sync::verify_attestation(
+    &attestation_report,
+    &vcek,
+    &ChainVerification::WithPinnedArk { ask: &ask },
+)?;
+```
+
+## Wasm
+
+Build the library for `wasm32` with the WebCrypto backend:
 
 ```bash
-cargo build --target wasm32-unknown-unknown --release
+wasm-pack build --target web -- --no-default-features --features "crypto_webcrypto"
 ```
 
-Use the low TCB variant in another project:
-```toml
-tee-attestation-verification = { default-features = false, features = ["crypto_openssl"], ...}
+For a plain Cargo build targeting `wasm32-unknown-unknown`:
+
+```bash
+cargo build --target wasm32-unknown-unknown --no-default-features --features "crypto_webcrypto"
 ```
 
 ## SEV-SNP Verification Process

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,10 @@ fn main() {
       panic!("`crypto_webcrypto` is only supported on wasm32 targets.");
     }
 
+    if has_openssl && target_arch == "wasm32" {
+        panic!("`crypto_openssl` is not supported on wasm32 targets.");
+    }
+
     let crypto_backend = if has_openssl {
         "crypto_openssl"
     } else if has_webcrypto {

--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,43 @@
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(sync_crypto)");
     println!("cargo:rustc-check-cfg=cfg(async_crypto)");
-    println!("cargo:rustc-check-cfg=cfg(crypto_backend, values(\"crypto_openssl\", \"crypto_pure_rust\"))");
+    println!(
+        "cargo:rustc-check-cfg=cfg(crypto_backend, values(\"crypto_openssl\", \"crypto_pure_rust\", \"crypto_webcrypto\"))"
+    );
 
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     let has_openssl = std::env::var_os("CARGO_FEATURE_CRYPTO_OPENSSL").is_some();
     let has_pure_rust = std::env::var_os("CARGO_FEATURE_CRYPTO_PURE_RUST").is_some();
+    let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
-    let crypto_backend = if has_pure_rust {
-        Some("crypto_pure_rust")
-    } else if has_openssl {
-        Some("crypto_openssl")
+    if has_webcrypto && target_arch != "wasm32" {
+      panic!("`crypto_webcrypto` is only supported on wasm32 targets.");
+    }
+
+    let crypto_backend = if has_openssl {
+        "crypto_openssl"
+    } else if has_webcrypto {
+        "crypto_webcrypto"
+    } else if has_pure_rust {
+        "crypto_pure_rust"
     } else {
-        None
+        panic!("At least one crypto backend must be enabled")
     };
 
-    if let Some(crypto_backend) = crypto_backend {
+    let backend_map= std::collections::BTreeMap::from([
+        ("crypto_openssl", (true, true)),
+        ("crypto_pure_rust", (true, true)),
+        ("crypto_webcrypto", (false, true)),
+    ]);
+
+    let (sync_crypto, async_crypto) = backend_map.get(crypto_backend).unwrap();
+
+    if *sync_crypto {
         println!("cargo:rustc-cfg=sync_crypto");
-        println!("cargo:rustc-cfg=async_crypto");
-        println!("cargo:rustc-cfg=crypto_backend=\"{crypto_backend}\"");
     }
+    if *async_crypto {
+        println!("cargo:rustc-cfg=async_crypto");
+    }
+
+    println!("cargo:rustc-cfg=crypto_backend=\"{crypto_backend}\"");
 }

--- a/build.rs
+++ b/build.rs
@@ -11,7 +11,7 @@ fn main() {
     let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
     if has_webcrypto && target_arch != "wasm32" {
-      panic!("`crypto_webcrypto` is only supported on wasm32 targets.");
+        panic!("`crypto_webcrypto` is only supported on wasm32 targets.");
     }
 
     if has_openssl && target_arch == "wasm32" {
@@ -28,7 +28,7 @@ fn main() {
         panic!("At least one crypto backend must be enabled")
     };
 
-    let backend_map= std::collections::BTreeMap::from([
+    let backend_map = std::collections::BTreeMap::from([
         ("crypto_openssl", (true, true)),
         ("crypto_pure_rust", (true, true)),
         ("crypto_webcrypto", (false, true)),

--- a/build.rs
+++ b/build.rs
@@ -11,11 +11,11 @@ fn main() {
     let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
     if has_webcrypto && target_arch != "wasm32" {
-        panic!("`crypto_webcrypto` is only supported on wasm32 targets.");
+        panic!("`crypto_webcrypto` is only supported on wasm32 targets, use `crypto_openssl` instead.");
     }
 
     if has_openssl && target_arch == "wasm32" {
-        panic!("`crypto_openssl` is not supported on wasm32 targets.");
+        panic!("`crypto_openssl` is not supported on wasm32 targets, use `crypto_webcrypto` instead.");
     }
 
     let crypto_backend = if has_openssl {

--- a/build.rs
+++ b/build.rs
@@ -18,7 +18,7 @@ fn main() {
 
     if has_openssl && target_arch == "wasm32" {
         panic!(
-            "`crypto_openssl` is not supported on wasm32 targets, use `crypto_webcrypto` instead."
+            "`crypto_openssl` is not supported on wasm32 targets, use `crypto_webcrypto` or `crypto_pure_rust` instead."
         );
     }
 
@@ -29,7 +29,7 @@ fn main() {
     } else if has_pure_rust {
         "crypto_pure_rust"
     } else {
-        panic!("At least one crypto backend must be enabled")
+        panic!("At least one crypto backend must be enabled, enable one of `crypto_openssl`, `crypto_webcrypto` or `crypto_pure_rust`.")
     };
 
     let backend_map = std::collections::BTreeMap::from([

--- a/build.rs
+++ b/build.rs
@@ -11,11 +11,15 @@ fn main() {
     let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
     if has_webcrypto && target_arch != "wasm32" {
-        panic!("`crypto_webcrypto` is only supported on wasm32 targets, use `crypto_openssl` instead.");
+        panic!(
+            "`crypto_webcrypto` is only supported on wasm32 targets, use `crypto_openssl` instead."
+        );
     }
 
     if has_openssl && target_arch == "wasm32" {
-        panic!("`crypto_openssl` is not supported on wasm32 targets, use `crypto_webcrypto` instead.");
+        panic!(
+            "`crypto_openssl` is not supported on wasm32 targets, use `crypto_webcrypto` instead."
+        );
     }
 
     let crypto_backend = if has_openssl {

--- a/src/certificate_chain.rs
+++ b/src/certificate_chain.rs
@@ -4,11 +4,11 @@
 #[cfg(not(any(feature = "online", target_arch = "wasm32")))]
 compile_error!("certificate_chain module requires either the 'online' feature or wasm32 target");
 
-use crate::crypto::Certificate;
-#[cfg(sync_crypto)]
-use crate::crypto::verifier::Sync as SyncVerifier;
 #[cfg(async_crypto)]
 use crate::crypto::verifier::Async as AsyncVerifier;
+#[cfg(sync_crypto)]
+use crate::crypto::verifier::Sync as SyncVerifier;
+use crate::crypto::Certificate;
 use crate::kds::KdsFetcher;
 #[cfg(sync_crypto)]
 use crate::pinned_arks;

--- a/src/certificate_chain.rs
+++ b/src/certificate_chain.rs
@@ -4,9 +4,13 @@
 #[cfg(not(any(feature = "online", target_arch = "wasm32")))]
 compile_error!("certificate_chain module requires either the 'online' feature or wasm32 target");
 
-use crate::crypto::verifier::Sync as Verifier;
 use crate::crypto::Certificate;
+#[cfg(sync_crypto)]
+use crate::crypto::verifier::Sync as SyncVerifier;
+#[cfg(async_crypto)]
+use crate::crypto::verifier::Async as AsyncVerifier;
 use crate::kds::KdsFetcher;
+#[cfg(sync_crypto)]
 use crate::pinned_arks;
 use crate::{snp, AttestationReport};
 use log::info;
@@ -65,6 +69,7 @@ impl AmdCertificates {
     ///
     /// # Returns
     /// A verified `AmdCertificates` instance, or an error if chain verification fails.
+    #[cfg(sync_crypto)]
     pub fn from_certs(
         attestation_report: &AttestationReport,
         ask: Certificate,
@@ -80,11 +85,11 @@ impl AmdCertificates {
         let ark = pinned_arks::get_ark(processor_model)?;
 
         // Verify chain: ARK signs ASK
-        ark.verify(&ask)
+        SyncVerifier::verify(&ark, &ask)
             .map_err(|e| format!("Failed to verify ASK signature against pinned ARK: {}", e))?;
 
         // Verify chain: ASK signs VCEK
-        ask.verify(&vcek)
+        SyncVerifier::verify(&ask, &vcek)
             .map_err(|e| format!("Failed to verify VCEK signature against ASK: {}", e))?;
 
         info!(
@@ -113,6 +118,7 @@ impl AmdCertificates {
     /// Get the VCEK certificate that was provided during construction (for offline verification).
     ///
     /// This method is intended for use with instances created via `from_certs`.
+    #[cfg(sync_crypto)]
     pub fn get_vcek_sync(
         &self,
         processor_model: snp::model::Generation,
@@ -148,7 +154,8 @@ impl AmdCertificates {
             .await
             .map_err(|e| format!("Error fetching chain: {}", e))?;
 
-        ark.verify(&ask)
+        verify_certificate_signature_async(&ark, &ask)
+            .await
             .map_err(|e| format!("Failed to verify ASK signature: {}", e))?;
 
         let chain = Chain { ark, ask };
@@ -180,9 +187,8 @@ impl AmdCertificates {
 
             // Verify that VCEK is signed by ASK
             let chain = self.get_chain(processor_model).await?;
-            chain
-                .ask
-                .verify(&vcek)
+            verify_certificate_signature_async(&chain.ask, &vcek)
+                .await
                 .map_err(|e| format!("Failed to verify VCEK signature: {}", e))?;
 
             info!(
@@ -207,6 +213,14 @@ impl AmdCertificates {
         );
         self.vcek_cache.contains_key(&cache_key)
     }
+}
+
+#[cfg(async_crypto)]
+async fn verify_certificate_signature_async(
+    issuer: &Certificate,
+    subject: &Certificate,
+) -> Result<(), Box<dyn std::error::Error>> {
+    AsyncVerifier::verify(issuer, subject).await
 }
 
 /// Trait for fetching AMD certificates from a certificate source

--- a/src/crypto/crypto_webcrypto.rs
+++ b/src/crypto/crypto_webcrypto.rs
@@ -175,13 +175,7 @@ async fn import_spki_key(
     let key_usages = JsValue::from(usages);
 
     let promise = subtle
-        .import_key_with_object(
-            "spki",
-            key_data.as_ref(),
-            algorithm,
-            false,
-            &key_usages,
-        )
+        .import_key_with_object("spki", key_data.as_ref(), algorithm, false, &key_usages)
         .map_err(js_error)?;
     let key = JsFuture::from(promise).await.map_err(js_error)?;
 

--- a/src/crypto/crypto_webcrypto.rs
+++ b/src/crypto/crypto_webcrypto.rs
@@ -169,16 +169,18 @@ async fn import_spki_key(
     spki_der: &[u8],
     algorithm: &Object,
 ) -> Result<CryptoKey> {
+    let key_data = Uint8Array::from(spki_der);
     let usages = Array::new();
     usages.push(&JsValue::from_str("verify"));
+    let key_usages = JsValue::from(usages);
 
     let promise = subtle
         .import_key_with_object(
             "spki",
-            Uint8Array::from(spki_der).as_ref(),
+            key_data.as_ref(),
             algorithm,
             false,
-            &usages,
+            &key_usages,
         )
         .map_err(js_error)?;
     let key = JsFuture::from(promise).await.map_err(js_error)?;

--- a/src/crypto/crypto_webcrypto.rs
+++ b/src/crypto/crypto_webcrypto.rs
@@ -28,8 +28,12 @@ impl Certificate {
 impl AsyncVerifier<Certificate> for Certificate {
     async fn verify(&self, subject: &Certificate) -> Result<()> {
         let subtle = subtle_crypto()?;
-        let key = import_certificate_signing_key(&subtle, &self.inner, subject.inner.signature_algorithm()?)
-            .await?;
+        let key = import_certificate_signing_key(
+            &subtle,
+            &self.inner,
+            subject.inner.signature_algorithm()?,
+        )
+        .await?;
         let signature = subject.inner.signature_bytes().to_vec();
         let data = subject.inner.tbs_certificate_der()?;
 

--- a/src/crypto/crypto_webcrypto.rs
+++ b/src/crypto/crypto_webcrypto.rs
@@ -1,0 +1,359 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![cfg(all(target_arch = "wasm32", feature = "crypto_webcrypto"))]
+
+use js_sys::{Array, Object, Promise, Reflect, Uint8Array};
+use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
+
+use super::verifier::Async as AsyncVerifier;
+use super::x509_certificate::{Certificate as X509Certificate, SignatureAlgorithm};
+use super::{AsyncCryptoBackend, CertificateBackend, Result};
+use crate::snp::report::{AttestationReport, Signature};
+
+pub struct Crypto;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Certificate {
+    inner: X509Certificate,
+}
+
+impl Certificate {
+    fn from_inner(inner: X509Certificate) -> Self {
+        Self { inner }
+    }
+}
+
+impl AsyncVerifier<Certificate> for Certificate {
+    async fn verify(&self, subject: &Certificate) -> Result<()> {
+        let subtle = subtle_crypto()?;
+        let key = import_certificate_signing_key(&subtle, &self.inner, subject.inner.signature_algorithm()?)
+            .await?;
+        let signature = subject.inner.signature_bytes().to_vec();
+        let data = subject.inner.tbs_certificate_der()?;
+
+        verify_signature(
+            &subtle,
+            &key,
+            WebCryptoVerifyAlgorithm::RsaPssSha384,
+            &signature,
+            &data,
+        )
+        .await
+    }
+}
+
+impl AsyncVerifier<AttestationReport> for Certificate {
+    async fn verify(&self, report: &AttestationReport) -> Result<()> {
+        let subtle = subtle_crypto()?;
+        let key = import_attestation_key(&subtle, &self.inner).await?;
+        let signature = attestation_signature_p1363(report.signature)?;
+
+        verify_signature(
+            &subtle,
+            &key,
+            WebCryptoVerifyAlgorithm::EcdsaP384Sha384,
+            &signature,
+            report.signed_bytes(),
+        )
+        .await
+    }
+}
+
+impl CertificateBackend for Crypto {
+    type Certificate = Certificate;
+
+    fn from_pem(pem: &[u8]) -> Result<Self::Certificate> {
+        Ok(Certificate::from_inner(X509Certificate::from_pem(pem)?))
+    }
+
+    fn from_pem_chain(pem: &[u8]) -> Result<Vec<Self::Certificate>> {
+        X509Certificate::from_pem_chain(pem)?
+            .into_iter()
+            .map(Certificate::from_inner)
+            .map(Ok)
+            .collect()
+    }
+
+    fn from_der(der: &[u8]) -> Result<Self::Certificate> {
+        Ok(Certificate::from_inner(X509Certificate::from_der(der)?))
+    }
+
+    fn to_der(cert: &Self::Certificate) -> Result<Vec<u8>> {
+        cert.inner.to_der()
+    }
+
+    fn to_pem(cert: &Self::Certificate) -> Result<String> {
+        cert.inner.to_pem()
+    }
+
+    fn get_public_key(cert: &Self::Certificate) -> Result<Vec<u8>> {
+        cert.inner.public_key_spki_der()
+    }
+
+    fn get_extension_value_by_oid(cert: &Self::Certificate, oid: &str) -> Result<Option<Vec<u8>>> {
+        cert.inner.get_extension_value_by_oid(oid)
+    }
+}
+
+impl AsyncCryptoBackend for Crypto {
+    type Certificate = Certificate;
+
+    async fn verify_chain(
+        trusted_certs: &[&Self::Certificate],
+        untrusted_chain: &[&Self::Certificate],
+        leaf: &Self::Certificate,
+    ) -> Result<()> {
+        let untrusted_chain = untrusted_chain.iter().chain(std::iter::once(&leaf));
+        let mut prev: Option<&Certificate> = None;
+
+        for &cert in untrusted_chain {
+            if let Some(issuer) = prev {
+                issuer.verify(cert).await?;
+            } else {
+                let mut verified = false;
+                for &trusted in trusted_certs {
+                    if trusted.verify(cert).await.is_ok() {
+                        verified = true;
+                        break;
+                    }
+                }
+
+                if !verified {
+                    return Err("Failed to verify certificate: no matching trusted issuer".into());
+                }
+            }
+
+            prev = Some(cert);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WebCryptoVerifyAlgorithm {
+    RsaPssSha384,
+    EcdsaP384Sha384,
+}
+
+async fn import_certificate_signing_key(
+    subtle: &SubtleCrypto,
+    cert: &X509Certificate,
+    signature_algorithm: SignatureAlgorithm,
+) -> Result<CryptoKey> {
+    let spki_der = cert.public_key_spki_der()?;
+    let params = match signature_algorithm {
+        SignatureAlgorithm::RsaPss => rsa_pss_import_params()?,
+    };
+
+    import_spki_key(subtle, &spki_der, &params).await
+}
+
+async fn import_attestation_key(
+    subtle: &SubtleCrypto,
+    cert: &X509Certificate,
+) -> Result<CryptoKey> {
+    let spki_der = cert.public_key_spki_der()?;
+    let params = ecdsa_import_params()?;
+    import_spki_key(subtle, &spki_der, &params).await
+}
+
+async fn import_spki_key(
+    subtle: &SubtleCrypto,
+    spki_der: &[u8],
+    algorithm: &Object,
+) -> Result<CryptoKey> {
+    let usages = Array::new();
+    usages.push(&JsValue::from_str("verify"));
+
+    let promise = subtle
+        .import_key_with_object(
+            "spki",
+            Uint8Array::from(spki_der).as_ref(),
+            algorithm,
+            false,
+            &usages,
+        )
+        .map_err(js_error)?;
+    let key = JsFuture::from(promise).await.map_err(js_error)?;
+
+    key.dyn_into::<CryptoKey>()
+        .map_err(|_| "WebCrypto importKey did not return a CryptoKey".into())
+}
+
+async fn verify_signature(
+    subtle: &SubtleCrypto,
+    key: &CryptoKey,
+    algorithm: WebCryptoVerifyAlgorithm,
+    signature: &[u8],
+    data: &[u8],
+) -> Result<()> {
+    let params = match algorithm {
+        WebCryptoVerifyAlgorithm::RsaPssSha384 => rsa_pss_verify_params()?,
+        WebCryptoVerifyAlgorithm::EcdsaP384Sha384 => ecdsa_verify_params()?,
+    };
+
+    let promise = subtle
+        .verify_with_object_and_u8_array_and_u8_array(&params, key, signature, data)
+        .map_err(js_error)?;
+    let verified = JsFuture::from(promise).await.map_err(js_error)?;
+
+    if verified.as_bool() == Some(true) {
+        Ok(())
+    } else {
+        Err("WebCrypto signature verification failed".into())
+    }
+}
+
+fn attestation_signature_p1363(signature: Signature) -> Result<Vec<u8>> {
+    let mut p1363 = Vec::with_capacity(96);
+
+    if signature.r[48..].iter().any(|byte| *byte != 0) {
+        return Err(
+            "Invalid r scalar padding: upper 24 bytes must be zero for P-384 signatures".into(),
+        );
+    }
+    let mut r_bytes: [u8; 48] = signature.r[..48]
+        .try_into()
+        .map_err(|_| "Invalid r scalar length")?;
+    r_bytes.reverse();
+
+    if signature.s[48..].iter().any(|byte| *byte != 0) {
+        return Err(
+            "Invalid s scalar padding: upper 24 bytes must be zero for P-384 signatures".into(),
+        );
+    }
+    let mut s_bytes: [u8; 48] = signature.s[..48]
+        .try_into()
+        .map_err(|_| "Invalid s scalar length")?;
+    s_bytes.reverse();
+
+    p1363.extend_from_slice(&r_bytes);
+    p1363.extend_from_slice(&s_bytes);
+    Ok(p1363)
+}
+
+fn subtle_crypto() -> Result<SubtleCrypto> {
+    let global = js_sys::global();
+    let crypto = Reflect::get(&global, &JsValue::from_str("crypto")).map_err(js_error)?;
+    if crypto.is_undefined() || crypto.is_null() {
+        return Err("globalThis.crypto is not available".into());
+    }
+
+    let subtle = Reflect::get(&crypto, &JsValue::from_str("subtle")).map_err(js_error)?;
+    if subtle.is_undefined() || subtle.is_null() {
+        return Err("globalThis.crypto.subtle is not available".into());
+    }
+
+    subtle
+        .dyn_into::<SubtleCrypto>()
+        .map_err(|_| "globalThis.crypto.subtle is not a SubtleCrypto object".into())
+}
+
+fn rsa_pss_import_params() -> Result<Object> {
+    let params = Object::new();
+    set_string(&params, "name", "RSA-PSS")?;
+    set_string(&params, "hash", "SHA-384")?;
+    Ok(params)
+}
+
+fn rsa_pss_verify_params() -> Result<Object> {
+    let params = Object::new();
+    set_string(&params, "name", "RSA-PSS")?;
+    Reflect::set(
+        &params,
+        &JsValue::from_str("saltLength"),
+        &JsValue::from_f64(48.0),
+    )
+    .map_err(js_error)?;
+    Ok(params)
+}
+
+fn ecdsa_import_params() -> Result<Object> {
+    let params = Object::new();
+    set_string(&params, "name", "ECDSA")?;
+    set_string(&params, "namedCurve", "P-384")?;
+    Ok(params)
+}
+
+fn ecdsa_verify_params() -> Result<Object> {
+    let params = Object::new();
+    set_string(&params, "name", "ECDSA")?;
+    set_string(&params, "hash", "SHA-384")?;
+    Ok(params)
+}
+
+fn set_string(target: &Object, key: &str, value: &str) -> Result<()> {
+    Reflect::set(target, &JsValue::from_str(key), &JsValue::from_str(value)).map_err(js_error)?;
+    Ok(())
+}
+
+fn js_error(error: JsValue) -> Box<dyn std::error::Error> {
+    format!("WebCrypto error: {:?}", error).into()
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "CryptoKey")]
+    type CryptoKey;
+
+    #[wasm_bindgen(typescript_type = "SubtleCrypto")]
+    type SubtleCrypto;
+
+    #[wasm_bindgen(method, structural, catch, js_name = importKey)]
+    fn import_key_with_object(
+        this: &SubtleCrypto,
+        format: &str,
+        key_data: &Object,
+        algorithm: &Object,
+        extractable: bool,
+        key_usages: &JsValue,
+    ) -> std::result::Result<Promise, JsValue>;
+
+    #[wasm_bindgen(method, structural, catch, js_name = verify)]
+    fn verify_with_object_and_u8_array_and_u8_array(
+        this: &SubtleCrypto,
+        algorithm: &Object,
+        key: &CryptoKey,
+        signature: &[u8],
+        data: &[u8],
+    ) -> std::result::Result<Promise, JsValue>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::Crypto;
+    use crate::crypto::{verifier::Async as AsyncVerifier, AsyncCryptoBackend, CertificateBackend};
+    use crate::AttestationReport;
+    use wasm_bindgen_test::wasm_bindgen_test;
+    use zerocopy::{IntoBytes, TryFromBytes};
+
+    const MILAN_VCEK: &[u8] = include_bytes!("test_data/milan_vcek.pem");
+    const MILAN_REPORT: &[u8] = include_bytes!("test_data/milan_attestation_report.bin");
+
+    fn cert(pem: &[u8]) -> <Crypto as AsyncCryptoBackend>::Certificate {
+        Crypto::from_pem(pem).unwrap()
+    }
+
+    #[wasm_bindgen_test]
+    async fn non_zero_scalar_padding_fails() {
+        let vcek = cert(MILAN_VCEK);
+        let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+            .expect("Failed to parse attestation report")
+            .clone();
+
+        report.signature.r[60] = 1;
+
+        let error = vcek
+            .verify(&report)
+            .await
+            .expect_err("Non-zero scalar padding should not verify");
+
+        assert!(
+            error.to_string().contains("Invalid r scalar padding"),
+            "Expected scalar padding error, got: {error:?}"
+        );
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -8,21 +8,6 @@
 //! - `crypto_pure_rust` - Pure Rust
 //! - `crypto_webcrypto` - WebCrypto-based async verification for WASM
 
-#[cfg(not(any(
-    feature = "crypto_openssl",
-    feature = "crypto_pure_rust",
-    feature = "crypto_webcrypto"
-)))]
-compile_error!(
-    "At least one crypto backend feature must be enabled: \
-     `crypto_openssl`, `crypto_pure_rust`, or `crypto_webcrypto`."
-);
-#[cfg(all(target_arch = "wasm32", crypto_backend = "crypto_openssl"))]
-compile_error!(
-    "`crypto_openssl` is not supported on wasm32 targets. Use `crypto_webcrypto` or `crypto_pure_rust` instead."
-);
-#[cfg(all(not(target_arch = "wasm32"), crypto_backend = "crypto_webcrypto"))]
-compile_error!("`crypto_webcrypto` is only supported on wasm32 targets.");
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 use crate::snp::report::AttestationReport;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -214,9 +214,10 @@ mod test {
         #[test]
         fn corrupted_report_fails_to_verify() {
             let vcek = cert(MILAN_VCEK);
-            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-                .expect("Failed to parse attestation report")
-                .clone();
+            let mut report: AttestationReport =
+                AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                    .expect("Failed to parse attestation report")
+                    .clone();
 
             let report_bytes = report.as_mut_bytes();
             report_bytes[100] ^= 0xFF;
@@ -228,9 +229,10 @@ mod test {
         #[test]
         fn corrupt_signature_fails() {
             let vcek = cert(MILAN_VCEK);
-            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-                .expect("Failed to parse attestation report")
-                .clone();
+            let mut report: AttestationReport =
+                AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                    .expect("Failed to parse attestation report")
+                    .clone();
 
             report.signature.r[0] ^= 0xFF;
 
@@ -241,9 +243,10 @@ mod test {
         #[test]
         fn zeroed_signature_fails() {
             let vcek = cert(MILAN_VCEK);
-            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-                .expect("Failed to parse attestation report")
-                .clone();
+            let mut report: AttestationReport =
+                AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                    .expect("Failed to parse attestation report")
+                    .clone();
 
             report.signature.r.fill(0);
             report.signature.s.fill(0);
@@ -308,9 +311,13 @@ mod test {
         #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         async fn self_signed_certificates() {
-            <Crypto as AsyncCryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_ARK))
-                .await
-                .unwrap();
+            <Crypto as AsyncCryptoBackend>::verify_chain(
+                &[&cert(MILAN_ARK)],
+                &[],
+                &cert(MILAN_ARK),
+            )
+            .await
+            .unwrap();
         }
 
         #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
@@ -337,9 +344,10 @@ mod test {
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         async fn corrupted_report_fails_to_verify() {
             let vcek = cert(MILAN_VCEK);
-            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-                .expect("Failed to parse attestation report")
-                .clone();
+            let mut report: AttestationReport =
+                AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                    .expect("Failed to parse attestation report")
+                    .clone();
 
             let report_bytes = report.as_mut_bytes();
             report_bytes[100] ^= 0xFF;
@@ -353,9 +361,10 @@ mod test {
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         async fn corrupt_signature_fails() {
             let vcek = cert(MILAN_VCEK);
-            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-                .expect("Failed to parse attestation report")
-                .clone();
+            let mut report: AttestationReport =
+                AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                    .expect("Failed to parse attestation report")
+                    .clone();
 
             report.signature.r[0] ^= 0xFF;
 
@@ -368,9 +377,10 @@ mod test {
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
         async fn zeroed_signature_fails() {
             let vcek = cert(MILAN_VCEK);
-            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-                .expect("Failed to parse attestation report")
-                .clone();
+            let mut report: AttestationReport =
+                AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                    .expect("Failed to parse attestation report")
+                    .clone();
 
             report.signature.r.fill(0);
             report.signature.s.fill(0);

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -19,7 +19,7 @@ compile_error!(
 );
 #[cfg(all(target_arch = "wasm32", crypto_backend = "crypto_openssl"))]
 compile_error!(
-    "`crypto_openssl` is not supported on wasm32 targets. Use `crypto_webcrypto` instead."
+    "`crypto_openssl` is not supported on wasm32 targets. Use `crypto_webcrypto` or `crypto_pure_rust` instead."
 );
 #[cfg(all(not(target_arch = "wasm32"), crypto_backend = "crypto_webcrypto"))]
 compile_error!("`crypto_webcrypto` is only supported on wasm32 targets.");

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -3,18 +3,26 @@
 
 //! Cryptographic backend for certificate and attestation verification.
 //!
-//! Supports sync verification backends via feature flags:
+//! Supports crypto backends via feature flags:
 //! - `crypto_openssl` - OpenSSL-based (not available on WASM)
-//! - `crypto_pure_rust` - Pure Rust (required for WASM)
-//!
-//! If both are enabled, `crypto_openssl` takes precedence.
+//! - `crypto_pure_rust` - Pure Rust
+//! - `crypto_webcrypto` - WebCrypto-based async verification for WASM
 
-#[cfg(not(sync_crypto))]
-compile_error!("Either `crypto_openssl` or `crypto_pure_rust` feature must be enabled.");
-#[cfg(all(target_arch = "wasm32", feature = "crypto_openssl"))]
+#[cfg(not(any(
+    feature = "crypto_openssl",
+    feature = "crypto_pure_rust",
+    feature = "crypto_webcrypto"
+)))]
 compile_error!(
-    "`crypto_openssl` is not supported on wasm32 targets. Use `crypto_pure_rust` instead."
+    "At least one crypto backend feature must be enabled: \
+     `crypto_openssl`, `crypto_pure_rust`, or `crypto_webcrypto`."
 );
+#[cfg(all(target_arch = "wasm32", crypto_backend = "crypto_openssl"))]
+compile_error!(
+    "`crypto_openssl` is not supported on wasm32 targets. Use `crypto_webcrypto` instead."
+);
+#[cfg(all(not(target_arch = "wasm32"), crypto_backend = "crypto_webcrypto"))]
+compile_error!("`crypto_webcrypto` is only supported on wasm32 targets.");
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 use crate::snp::report::AttestationReport;
@@ -36,8 +44,8 @@ pub mod verifier {
     where
         V: Sync<T>,
     {
-        fn verify(&self, data: &T) -> impl std::future::Future<Output = Result<()>> {
-            std::future::ready(Sync::verify(self, data))
+        async fn verify(&self, data: &T) -> Result<()> {
+            Sync::verify(self, data)
         }
     }
 }
@@ -106,16 +114,12 @@ where
 {
     type Certificate = <C as CertificateBackend>::Certificate;
 
-    fn verify_chain(
+    async fn verify_chain(
         trusted_certs: &[&Self::Certificate],
         untrusted_chain: &[&Self::Certificate],
         leaf: &Self::Certificate,
-    ) -> impl std::future::Future<Output = Result<()>> {
-        std::future::ready(<C as CryptoBackend>::verify_chain(
-            trusted_certs,
-            untrusted_chain,
-            leaf,
-        ))
+    ) -> Result<()> {
+        <C as CryptoBackend>::verify_chain(trusted_certs, untrusted_chain, leaf)
     }
 }
 
@@ -123,20 +127,24 @@ where
 pub(crate) mod crypto_openssl;
 #[cfg(feature = "crypto_pure_rust")]
 pub(crate) mod crypto_pure_rust;
-#[cfg(feature = "crypto_pure_rust")]
+#[cfg(feature = "crypto_webcrypto")]
+pub(crate) mod crypto_webcrypto;
+#[cfg(any(feature = "crypto_pure_rust", feature = "crypto_webcrypto"))]
 mod x509_certificate;
 
 #[cfg(crypto_backend = "crypto_openssl")]
 pub type Crypto = crypto_openssl::Crypto;
 #[cfg(crypto_backend = "crypto_pure_rust")]
 pub type Crypto = crypto_pure_rust::Crypto;
+#[cfg(crypto_backend = "crypto_webcrypto")]
+pub type Crypto = crypto_webcrypto::Crypto;
 
 /// The certificate type for the active crypto backend.
 pub type Certificate = <Crypto as CertificateBackend>::Certificate;
 
 #[cfg(test)]
 mod test {
-    use super::verifier::Sync as Verifier;
+    use crate::AttestationReport;
     use zerocopy::{IntoBytes, TryFromBytes};
 
     use super::Crypto;
@@ -152,107 +160,237 @@ mod test {
         Crypto::from_pem(pem).unwrap()
     }
 
-    #[test]
-    fn full_chain_verifies() {
-        <Crypto as CryptoBackend>::verify_chain(
-            &[&cert(MILAN_ARK)],
-            &[&cert(MILAN_ASK)],
-            &cert(MILAN_VCEK),
-        )
-        .unwrap();
-    }
+    #[cfg(sync_crypto)]
+    mod sync_tests {
+        use super::super::verifier::Sync as Verifier;
+        use super::*;
 
-    #[test]
-    fn empty_trust_store_fails() {
-        <Crypto as CryptoBackend>::verify_chain(&[], &[], &cert(MILAN_VCEK))
-            .expect_err("Should fail with no trusted certs");
-    }
-
-    #[test]
-    fn untrusted_intermediates_are_required() {
-        <Crypto as CryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_VCEK))
-            .expect_err("VCEK should not verify without ASK intermediate");
-    }
-
-    #[test]
-    fn self_signed_certificates() {
-        <Crypto as CryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_ARK))
+        #[test]
+        fn full_chain_verifies() {
+            <Crypto as CryptoBackend>::verify_chain(
+                &[&cert(MILAN_ARK)],
+                &[&cert(MILAN_ASK)],
+                &cert(MILAN_VCEK),
+            )
             .unwrap();
+        }
+
+        #[test]
+        fn empty_trust_store_fails() {
+            <Crypto as CryptoBackend>::verify_chain(&[], &[], &cert(MILAN_VCEK))
+                .expect_err("Should fail with no trusted certs");
+        }
+
+        #[test]
+        fn untrusted_intermediates_are_required() {
+            <Crypto as CryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_VCEK))
+                .expect_err("VCEK should not verify without ASK intermediate");
+        }
+
+        #[test]
+        fn self_signed_certificates() {
+            <Crypto as CryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_ARK))
+                .unwrap();
+        }
+
+        #[test]
+        fn verifier_trait_impl() {
+            let ark = cert(MILAN_ARK);
+            let ask = cert(MILAN_ASK);
+
+            ark.verify(&ark).unwrap();
+            ark.verify(&ask).unwrap();
+        }
+
+        #[test]
+        fn attestation_report_signature_verifies() {
+            let vcek = cert(MILAN_VCEK);
+            let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+            vcek.verify(&report).unwrap();
+        }
+
+        #[test]
+        fn corrupted_report_fails_to_verify() {
+            let vcek = cert(MILAN_VCEK);
+            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+
+            let report_bytes = report.as_mut_bytes();
+            report_bytes[100] ^= 0xFF;
+
+            vcek.verify(&report)
+                .expect_err("Corrupted report should not verify");
+        }
+
+        #[test]
+        fn corrupt_signature_fails() {
+            let vcek = cert(MILAN_VCEK);
+            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+
+            report.signature.r[0] ^= 0xFF;
+
+            vcek.verify(&report)
+                .expect_err("Corrupt signature should not verify");
+        }
+
+        #[test]
+        fn zeroed_signature_fails() {
+            let vcek = cert(MILAN_VCEK);
+            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+
+            report.signature.r.fill(0);
+            report.signature.s.fill(0);
+
+            vcek.verify(&report)
+                .expect_err("Zeroed signature should not verify");
+        }
+
+        #[test]
+        fn wrong_cert_rejects_signature() {
+            let vcek = cert(GENOA_VCEK);
+            let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+
+            vcek.verify(&report)
+                .expect_err("Wrong cert should not verify report");
+        }
     }
 
-    #[test]
-    fn verifier_trait_impl() {
-        let ark = cert(MILAN_ARK);
-        let ask = cert(MILAN_ASK);
+    #[cfg(async_crypto)]
+    mod async_tests {
+        use super::super::verifier::Async as Verifier;
+        use super::super::AsyncCryptoBackend;
+        use super::*;
 
-        // Self signed
-        ark.verify(&ark).unwrap();
-        // Signed by ARK
-        ark.verify(&ask).unwrap();
-    }
+        #[cfg(target_arch = "wasm32")]
+        use wasm_bindgen_test::wasm_bindgen_test;
 
-    #[test]
-    fn attestation_report_signature_verifies() {
-        let vcek = cert(MILAN_VCEK);
-        let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
-        vcek.verify(&report).unwrap();
-    }
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn full_chain_verifies() {
+            <Crypto as AsyncCryptoBackend>::verify_chain(
+                &[&cert(MILAN_ARK)],
+                &[&cert(MILAN_ASK)],
+                &cert(MILAN_VCEK),
+            )
+            .await
+            .unwrap();
+        }
 
-    #[test]
-    fn corrupted_report_fails_to_verify() {
-        let vcek = cert(MILAN_VCEK);
-        let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn empty_trust_store_fails() {
+            <Crypto as AsyncCryptoBackend>::verify_chain(&[], &[], &cert(MILAN_VCEK))
+                .await
+                .expect_err("Should fail with no trusted certs");
+        }
 
-        // Corrupt a byte in the signed portion
-        let report_bytes = report.as_mut_bytes();
-        report_bytes[100] ^= 0xFF;
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn untrusted_intermediates_are_required() {
+            <Crypto as AsyncCryptoBackend>::verify_chain(
+                &[&cert(MILAN_ARK)],
+                &[],
+                &cert(MILAN_VCEK),
+            )
+            .await
+            .expect_err("VCEK should not verify without ASK intermediate");
+        }
 
-        vcek.verify(&report)
-            .expect_err("Corrupted report should not verify");
-    }
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn self_signed_certificates() {
+            <Crypto as AsyncCryptoBackend>::verify_chain(&[&cert(MILAN_ARK)], &[], &cert(MILAN_ARK))
+                .await
+                .unwrap();
+        }
 
-    #[test]
-    fn corrupt_signature_fails() {
-        let vcek = cert(MILAN_VCEK);
-        let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn verifier_trait_impl() {
+            let ark = cert(MILAN_ARK);
+            let ask = cert(MILAN_ASK);
 
-        // Flip a byte in the ECDSA r component
-        report.signature.r[0] ^= 0xFF;
+            ark.verify(&ark).await.unwrap();
+            ark.verify(&ask).await.unwrap();
+        }
 
-        vcek.verify(&report)
-            .expect_err("Corrupt signature should not verify");
-    }
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn attestation_report_signature_verifies() {
+            let vcek = cert(MILAN_VCEK);
+            let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+            vcek.verify(&report).await.unwrap();
+        }
 
-    #[test]
-    fn zeroed_signature_fails() {
-        let vcek = cert(MILAN_VCEK);
-        let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn corrupted_report_fails_to_verify() {
+            let vcek = cert(MILAN_VCEK);
+            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
 
-        // Zero out both r and s
-        report.signature.r.fill(0);
-        report.signature.s.fill(0);
+            let report_bytes = report.as_mut_bytes();
+            report_bytes[100] ^= 0xFF;
 
-        vcek.verify(&report)
-            .expect_err("Zeroed signature should not verify");
-    }
+            vcek.verify(&report)
+                .await
+                .expect_err("Corrupted report should not verify");
+        }
 
-    #[test]
-    fn wrong_cert_rejects_signature() {
-        // Genoa VCEK is not the correct signer for the Milan report
-        let vcek = cert(GENOA_VCEK);
-        let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
-            .expect("Failed to parse attestation report")
-            .clone();
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn corrupt_signature_fails() {
+            let vcek = cert(MILAN_VCEK);
+            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
 
-        vcek.verify(&report)
-            .expect_err("Wrong cert should not verify report");
+            report.signature.r[0] ^= 0xFF;
+
+            vcek.verify(&report)
+                .await
+                .expect_err("Corrupt signature should not verify");
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn zeroed_signature_fails() {
+            let vcek = cert(MILAN_VCEK);
+            let mut report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+
+            report.signature.r.fill(0);
+            report.signature.s.fill(0);
+
+            vcek.verify(&report)
+                .await
+                .expect_err("Zeroed signature should not verify");
+        }
+
+        #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+        async fn wrong_cert_rejects_signature() {
+            let vcek = cert(GENOA_VCEK);
+            let report: AttestationReport = AttestationReport::try_read_from_bytes(MILAN_REPORT)
+                .expect("Failed to parse attestation report")
+                .clone();
+
+            vcek.verify(&report)
+                .await
+                .expect_err("Wrong cert should not verify report");
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub fn init() {
 }
 
 /// JavaScript-facing verification function
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", feature="serde"))]
 #[wasm_bindgen]
 pub async fn verify_attestation_report(attestation_report_json: &str) -> Result<(), String> {
     let attestation_report: AttestationReport = serde_json::from_str(attestation_report_json)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub fn init() {
 }
 
 /// JavaScript-facing verification function
-#[cfg(all(target_arch = "wasm32", feature="serde"))]
+#[cfg(all(target_arch = "wasm32", feature = "serde"))]
 #[wasm_bindgen]
 pub async fn verify_attestation_report(attestation_report_json: &str) -> Result<(), String> {
     let attestation_report: AttestationReport = serde_json::from_str(attestation_report_json)

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use tee_attestation_verification_lib::snp::verify::{self, ChainVerification};
+use tee_attestation_verification_lib::snp::verify::ChainVerification;
 #[cfg(any(target_family = "wasm", feature = "online"))]
 use tee_attestation_verification_lib::SevVerifier;
 use tee_attestation_verification_lib::{certificate_from_pem, AttestationReport};
@@ -22,6 +22,58 @@ pub const MILAN_VCEK: &[u8] = include_bytes!("test_data/milan_vcek.pem");
 pub const GENOA_VCEK: &[u8] = include_bytes!("test_data/genoa_vcek.pem");
 pub const TURIN_VCEK: &[u8] = include_bytes!("test_data/turin_vcek.pem");
 
+macro_rules! attestation_tests {
+    ($milan_ask:expr, $genoa_ask:expr, $turin_ask:expr, $tampered_milan_attestation:expr) => {
+        [
+            (
+                "genoa_ok_pinned",
+                GENOA_ATTESTATION,
+                GENOA_VCEK,
+                ChainVerification::WithPinnedArk { ask: &$genoa_ask },
+                Ok(()),
+            ),
+            (
+                "turin_ok_pinned",
+                TURIN_ATTESTATION,
+                TURIN_VCEK,
+                ChainVerification::WithPinnedArk { ask: &$turin_ask },
+                Ok(()),
+            ),
+            (
+                "milan_ok_pinned",
+                MILAN_ATTESTATION,
+                MILAN_VCEK,
+                ChainVerification::WithPinnedArk { ask: &$milan_ask },
+                Ok(()),
+            ),
+            (
+                "milan_invalid_root_certificate",
+                MILAN_ATTESTATION,
+                MILAN_VCEK,
+                ChainVerification::WithProvidedArk {
+                    ask: &$milan_ask,
+                    ark: &$milan_ask,
+                },
+                Err("Invalid root certificate"),
+            ),
+            (
+                "milan_genoa_ask",
+                MILAN_ATTESTATION,
+                MILAN_VCEK,
+                ChainVerification::WithPinnedArk { ask: &$genoa_ask },
+                Err("Certificate chain error"),
+            ),
+            (
+                "tampered_attestation",
+                &$tampered_milan_attestation,
+                MILAN_VCEK,
+                ChainVerification::Skip,
+                Err("Signature verification error"),
+            ),
+        ]
+    };
+}
+
 #[cfg(sync_crypto)]
 pub fn test_verify_attestation_suite() {
     let tampered_milan_attestation = {
@@ -34,58 +86,51 @@ pub fn test_verify_attestation_suite() {
     let genoa_ask = certificate_from_pem(GENOA_ASK).unwrap();
     let turin_ask = certificate_from_pem(TURIN_ASK).unwrap();
 
-    let tests = [
-        (
-            "genoa_ok_pinned",
-            GENOA_ATTESTATION,
-            GENOA_VCEK,
-            ChainVerification::WithPinnedArk { ask: &genoa_ask },
-            Ok(()),
-        ),
-        (
-            "turin_ok_pinned",
-            TURIN_ATTESTATION,
-            TURIN_VCEK,
-            ChainVerification::WithPinnedArk { ask: &turin_ask },
-            Ok(()),
-        ),
-        (
-            "milan_ok_pinned",
-            MILAN_ATTESTATION,
-            MILAN_VCEK,
-            ChainVerification::WithPinnedArk { ask: &milan_ask },
-            Ok(()),
-        ),
-        (
-            "milan_invalid_root_certificate",
-            MILAN_ATTESTATION,
-            MILAN_VCEK,
-            ChainVerification::WithProvidedArk {
-                ask: &milan_ask,
-                ark: &milan_ask,
-            },
-            Err("Invalid root certificate"),
-        ),
-        (
-            "milan_genoa_ask",
-            MILAN_ATTESTATION,
-            MILAN_VCEK,
-            ChainVerification::WithPinnedArk { ask: &genoa_ask },
-            Err("Certificate chain error"),
-        ),
-        (
-            "tampered_attestation",
-            &tampered_milan_attestation,
-            MILAN_VCEK,
-            ChainVerification::Skip,
-            Err("Signature verification error"),
-        ),
-    ];
-
-    for (tag, att, vcek, chain, expected) in tests {
+    for (tag, att, vcek, chain, expected) in
+        attestation_tests!(milan_ask, genoa_ask, turin_ask, tampered_milan_attestation)
+    {
         let report = AttestationReport::read_from_bytes(att).unwrap();
         let vcek = certificate_from_pem(vcek).unwrap();
-        let result = verify::sync::verify_attestation(&report, &vcek, &chain);
+        let result = tee_attestation_verification_lib::snp::verify::sync::verify_attestation(
+            &report, &vcek, &chain,
+        );
+
+        if let Err(e_str) = expected {
+            let err = result.expect_err(&format!("{}: Expected to fail with {}", tag, e_str));
+            assert!(
+                err.to_string().contains(e_str),
+                "{}: Expected error to contain '{}', got: {:?}",
+                tag,
+                e_str,
+                err
+            );
+        } else {
+            result.expect(&format!("{}: Expected verification to succeed", tag))
+        };
+    }
+}
+
+#[cfg(async_crypto)]
+pub async fn test_verify_attestation_suite_async() {
+    let tampered_milan_attestation = {
+        let mut tampered = MILAN_ATTESTATION.to_vec();
+        tampered[100] ^= 0xFF;
+        tampered
+    };
+    let milan_ask = certificate_from_pem(MILAN_ASK).unwrap();
+    let genoa_ask = certificate_from_pem(GENOA_ASK).unwrap();
+    let turin_ask = certificate_from_pem(TURIN_ASK).unwrap();
+
+    for (tag, att, vcek, chain, expected) in
+        attestation_tests!(milan_ask, genoa_ask, turin_ask, tampered_milan_attestation)
+    {
+        let report = AttestationReport::read_from_bytes(att).unwrap();
+        let vcek = certificate_from_pem(vcek).unwrap();
+        let result =
+            tee_attestation_verification_lib::snp::verify::asynchronous::verify_attestation(
+                &report, &vcek, &chain,
+            )
+            .await;
 
         if let Err(e_str) = expected {
             let err = result.expect_err(&format!("{}: Expected to fail with {}", tag, e_str));

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -147,7 +147,7 @@ pub async fn test_verify_attestation_suite_async() {
     }
 }
 
-#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
+#[cfg(all(feature = "online", async_crypto))]
 pub async fn verify_attestation_bytes(bytes: &[u8]) -> Result<(), String> {
     let attestation_report = AttestationReport::read_from_bytes(bytes)
         .map_err(|e| format!("Failed to read attestation report: {:?}", e))?;
@@ -162,17 +162,17 @@ pub async fn verify_attestation_bytes(bytes: &[u8]) -> Result<(), String> {
         .map_err(|e| format!("Verification call failed: {:?}", e))
 }
 
-#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
+#[cfg(all(feature = "online", async_crypto))]
 pub async fn verify_milan_attestation() -> Result<(), String> {
     verify_attestation_bytes(MILAN_ATTESTATION).await
 }
 
-#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
+#[cfg(all(feature = "online", async_crypto))]
 pub async fn verify_genoa_attestation() -> Result<(), String> {
     verify_attestation_bytes(GENOA_ATTESTATION).await
 }
 
-#[cfg(all(any(target_family = "wasm", feature = "online"), async_crypto))]
+#[cfg(all(feature = "online", async_crypto))]
 pub async fn verify_turin_attestation() -> Result<(), String> {
     verify_attestation_bytes(TURIN_ATTESTATION).await
 }

--- a/tests/tests_native.rs
+++ b/tests/tests_native.rs
@@ -57,3 +57,15 @@ mod offline {
         common::test_verify_attestation_suite();
     }
 }
+
+/// Offline verification tests (async, uses pinned ARKs)
+#[cfg(async_crypto)]
+mod offline_async {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_suite() {
+        init_logger();
+        common::test_verify_attestation_suite_async().await;
+    }
+}

--- a/tests/tests_node.rs
+++ b/tests/tests_node.rs
@@ -25,6 +25,7 @@ fn init_logger() {
 }
 
 /// Online verification tests (async, fetches certs from AMD KDS)
+#[cfg(feature = "online")]
 mod online {
     use super::*;
 

--- a/tests/tests_node.rs
+++ b/tests/tests_node.rs
@@ -53,6 +53,18 @@ mod online {
     }
 }
 
+/// Offline verification tests (async, uses explicit collateral)
+#[cfg(async_crypto)]
+mod offline_async {
+    use super::*;
+
+    #[wasm_bindgen_test]
+    async fn test_suite() {
+        init_logger();
+        common::test_verify_attestation_suite_async().await;
+    }
+}
+
 /// Offline verification tests (sync, uses pinned ARKs)
 #[cfg(sync_crypto)]
 mod offline {


### PR DESCRIPTION
This adds a webcrypto backend.
The constraint is that it only supports async, so we cannot have any sync verifiers.

So build.rs got added in #25 but needed extended for this PR, and the error messages cleaned up substantially.

Re testing:
- Removed CI to build wams instead just using the wasm-pack which builds it.
- async tests added to crypto/mod.rs to test whatever backend is enabled.
- tests/common.rs now use a macro for the test suite such that both the sync and async variations can work properly.

Review this in commit order (changes have been rebased to have clean commits). 

In another PR we need to refactor the SevVerifier, here I just made the minimal changes required to make it build.

