### PR TITLE
Remove serde dependency and clean up feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Test WASM offline with WebCrypto backend
         run: wasm-pack test --node --no-default-features --features "crypto_webcrypto"
 
-      - name: Test WASM online (optional - may fail due to KDS rate limiting)
+      - name: Test WASM with KDS (optional - may fail due to KDS rate limiting)
         continue-on-error: true
-        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust,serde,online"
+        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust,kds"
 
   native-openssl:
     name: Native openssl
@@ -69,12 +69,12 @@ jobs:
       - name: Build with openssl
         run: cargo build --no-default-features --features "crypto_openssl"
 
-      - name: Test offline with openssl
+      - name: Test with openssl
         run: cargo test --no-default-features --features "crypto_openssl" -- --nocapture
 
-      - name: Test online with openssl (optional - may fail due to KDS rate limiting)
+      - name: Test with openssl + KDS (optional - may fail due to KDS rate limiting)
         continue-on-error: true
-        run: cargo test --no-default-features --features "crypto_openssl,online" -- --nocapture
+        run: cargo test --no-default-features --features "crypto_openssl,kds" -- --nocapture
 
   native-pure-rust:
     name: Native pure-rust
@@ -89,5 +89,9 @@ jobs:
       - name: Build with pure_rust crypto
         run: cargo build --no-default-features --features "crypto_pure_rust"
 
-      - name: Test offline with pure_rust crypto
+      - name: Test with pure_rust crypto
         run: cargo test --no-default-features --features "crypto_pure_rust" -- --nocapture
+
+      - name: Test with pure_rust + KDS (optional - may fail due to KDS rate limiting)
+        continue-on-error: true
+        run: cargo test --no-default-features --features "crypto_pure_rust,kds" -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,15 +891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,9 +1021,6 @@ dependencies = [
  "openssl-sys",
  "p384",
  "rsa",
- "serde",
- "serde-big-array",
- "serde_json",
  "sha2",
  "tokio",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ path = "src/lib.rs"
 crypto_openssl = ["dep:foreign-types", "dep:openssl", "dep:openssl-sys"]
 crypto_pure_rust = ["dep:ecdsa", "dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 crypto_webcrypto = ["dep:x509-cert"]
-online = ["dep:curl", "dep:tokio"]
+kds = ["dep:curl", "dep:tokio"]
 
 
 [[bin]]
 name = "verify-attestation"
 path = "src/bin/verify_cli.rs"
-required-features = ["online"]
+required-features = ["kds"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
@@ -45,7 +45,7 @@ sha2 = {version = "0.10", optional = true}
 x509-cert = { version = "0.2", optional = true }
 zerocopy = {version = "0.8.31", features = ["derive"]}
 
-# Online dependencies
+# KDS (online certificate fetching) dependencies
 log = { version = "0.4" }
 
 # WASM deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/lib.rs"
 crypto_openssl = ["dep:foreign-types", "dep:openssl", "dep:openssl-sys"]
 crypto_pure_rust = ["dep:ecdsa", "dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 crypto_webcrypto = ["dep:x509-cert"]
-serde = ["dep:serde", "dep:serde-big-array", "dep:serde_json"]
 online = ["dep:curl", "dep:tokio"]
 
 
@@ -45,11 +44,6 @@ rsa = { version = "0.9", optional = true }
 sha2 = {version = "0.10", optional = true}
 x509-cert = { version = "0.2", optional = true }
 zerocopy = {version = "0.8.31", features = ["derive"]}
-
-# Serde (optional, enabled by default)
-serde = { version = "1.0", features = ["derive", "std", "alloc"], optional = true }
-serde_json = { version = "1.0", optional = true }
-serde-big-array = { version = "0.5.1", optional = true }
 
 # Online dependencies
 log = { version = "0.4" }

--- a/README.md
+++ b/README.md
@@ -8,16 +8,34 @@ A minimal-external-dependencies, portable and safe library for verifying a TEE a
 - **WASM-Compatible**: Build for `wasm32` with a WebCrypto backend
 - **Azure Linux 3.0 compatible**: Build for Azure Linux 3.0, with `rust-openssl` as the sole dependency.
 
+## Crypto Backends
+
+Exactly one crypto backend must be enabled:
+
+| Feature | Platforms | sync | async | Dependencies |
+|---|---|---|---|---|
+| `crypto_openssl` | Native | ✓ | ✓ | OpenSSL |
+| `crypto_pure_rust` | Native, WASM | ✓ | ✓ | Pure Rust (`p384`, `rsa`, `sha2`) |
+| `crypto_webcrypto` | WASM only | | ✓ | WebCrypto API |
+
+## Optional Features
+
+| Feature | Description |
+|---|---|
+| `kds` | Enables automatic certificate fetching from AMD's Key Distribution Service. Uses `curl`/`tokio` on native, `globalThis.fetch` on WASM. |
+
 ## Usage
 
-Add the library to your `Cargo.toml` with a native crypto backend:
+Add the library to your `Cargo.toml` with a crypto backend:
 
 ```toml
 [dependencies]
 tee-attestation-verification-lib = { version = "0.1.0", features = ["crypto_openssl"] }
 ```
 
-Then verify an attestation report with the synchronous `snp::verify::sync` API:
+### Offline verification (caller provides certificates)
+
+Parse the attestation report from its raw 1184-byte binary representation and verify with the synchronous API:
 
 ```rust
 use tee_attestation_verification_lib::snp::verify::{sync, ChainVerification};
@@ -35,18 +53,37 @@ sync::verify_attestation(
 )?;
 ```
 
-## Wasm
+### KDS verification (automatic certificate fetching)
+
+Enable the `kds` feature to let the library fetch certificates from AMD's KDS:
+
+```toml
+[dependencies]
+tee-attestation-verification-lib = { version = "0.1.0", features = ["crypto_openssl", "kds"] }
+```
+
+```rust
+use tee_attestation_verification_lib::{AttestationReport, SevVerifier};
+use zerocopy::FromBytes;
+
+let attestation_report = AttestationReport::read_from_bytes(attestation_bytes)?;
+
+let mut verifier = SevVerifier::new().await?;
+verifier.verify_attestation(&attestation_report).await?;
+```
+
+## WASM
 
 Build the library for `wasm32` with the WebCrypto backend:
 
 ```bash
-wasm-pack build --target web -- --no-default-features --features "crypto_webcrypto"
+wasm-pack build --target web -- --no-default-features --features "crypto_webcrypto,kds"
 ```
 
 For a plain Cargo build targeting `wasm32-unknown-unknown`:
 
 ```bash
-cargo build --target wasm32-unknown-unknown --no-default-features --features "crypto_webcrypto"
+cargo build --target wasm32-unknown-unknown --no-default-features --features "crypto_webcrypto,kds"
 ```
 
 ## SEV-SNP Verification Process
@@ -57,4 +94,4 @@ cargo build --target wasm32-unknown-unknown --no-default-features --features "cr
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/src/certificate_chain.rs
+++ b/src/certificate_chain.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[cfg(not(any(feature = "online", target_arch = "wasm32")))]
-compile_error!("certificate_chain module requires either the 'online' feature or wasm32 target");
+#[cfg(not(feature = "kds"))]
+compile_error!("certificate_chain module requires the 'kds' feature");
 
 #[cfg(async_crypto)]
 use crate::crypto::verifier::Async as AsyncVerifier;

--- a/src/kds.rs
+++ b/src/kds.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[cfg(not(any(feature = "online", target_arch = "wasm32")))]
-compile_error!("kds module requires either the 'online' feature or wasm32 target");
+#[cfg(not(feature = "kds"))]
+compile_error!("kds module requires the 'kds' feature");
 
 use crate::crypto::{Certificate, CertificateBackend, Crypto};
 use crate::snp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,13 @@ pub fn init() {
 }
 
 /// JavaScript-facing verification function
-#[cfg(all(target_arch = "wasm32", feature = "serde"))]
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
-pub async fn verify_attestation_report(attestation_report_json: &str) -> Result<(), String> {
-    let attestation_report: AttestationReport = serde_json::from_str(attestation_report_json)
-        .map_err(|e| format!("Failed to parse attestation report: {}", e))?;
+pub async fn verify_attestation_report(attestation_report_bytes: &[u8]) -> Result<(), String> {
+    use zerocopy::FromBytes;
+
+    let attestation_report = AttestationReport::read_from_bytes(attestation_report_bytes)
+        .map_err(|e| format!("Failed to parse attestation report: {:?}", e))?;
 
     let mut verifier = SevVerifier::new()
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! WASM-compatible helper crate for Patty
+//! Portable TEE attestation verification library.
 //!
-//! This crate will host SEV-SNP verification code that can be compiled for both
-//! native service usage and for browser/WASM relying parties. For now it re-exports
-//! the `sev_verification` module which contains the verification engine.
+//! Supports SEV-SNP attestation verification with pluggable crypto backends
+//! (`crypto_openssl`, `crypto_pure_rust`, `crypto_webcrypto`) and optional
+//! online certificate fetching from AMD KDS (`kds` feature).
 
 pub(crate) mod crypto;
 pub mod pinned_arks;
@@ -25,42 +25,16 @@ pub fn certificate_from_der(der: &[u8]) -> Result<Certificate, Box<dyn std::erro
     Crypto::from_der(der)
 }
 
-#[cfg(any(feature = "online", target_arch = "wasm32"))]
+#[cfg(feature = "kds")]
 mod certificate_chain;
-#[cfg(any(feature = "online", target_arch = "wasm32"))]
+#[cfg(feature = "kds")]
 mod kds;
-#[cfg(any(feature = "online", target_arch = "wasm32"))]
+#[cfg(feature = "kds")]
 pub mod sev_verification;
-#[cfg(any(feature = "online", target_arch = "wasm32"))]
+#[cfg(feature = "kds")]
 pub use certificate_chain::AmdCertificates;
-#[cfg(any(feature = "online", target_arch = "wasm32"))]
+#[cfg(feature = "kds")]
 pub use sev_verification::SevVerifier;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-
-/// Initialize the WASM module with panic hook and logging
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen(start)]
-pub fn init() {
-    console_error_panic_hook::set_once();
-    wasm_logger::init(wasm_logger::Config::default());
-}
-
-/// JavaScript-facing verification function
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-pub async fn verify_attestation_report(attestation_report_bytes: &[u8]) -> Result<(), String> {
-    use zerocopy::FromBytes;
-
-    let attestation_report = AttestationReport::read_from_bytes(attestation_report_bytes)
-        .map_err(|e| format!("Failed to parse attestation report: {:?}", e))?;
-
-    let mut verifier = SevVerifier::new()
-        .await
-        .map_err(|e| format!("Failed to initialize verifier: {}", e))?;
-    verifier
-        .verify_attestation(&attestation_report)
-        .await
-        .map_err(|e| format!("Verification failed: {:?}", e))
-}
+#[cfg(all(target_arch = "wasm32", feature = "kds"))]
+pub mod wasm;

--- a/src/sev_verification.rs
+++ b/src/sev_verification.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! WASM-only AMD SEV-SNP Attestation Verification
+//! AMD SEV-SNP Attestation Verification with KDS certificate fetching.
 //!
-//! This implementation is designed to be compiled only for wasm32 and uses
-//! wasm-bindgen for fetching KDS artifacts via an extension-provided JS bridge.
+//! Uses `SevVerifier` to automatically fetch certificate collateral from
+//! AMD's Key Distribution Service, verifying the chain before validating
+//! the attestation report.
 
-#[cfg(not(any(feature = "online", target_arch = "wasm32")))]
-compile_error!("sev_verification module requires either the 'online' feature or wasm32 target");
+#[cfg(not(feature = "kds"))]
+compile_error!("sev_verification module requires the 'kds' feature");
 
 use crate::certificate_chain::AmdCertificates;
 use crate::{snp, AttestationReport};

--- a/src/snp/report.rs
+++ b/src/snp/report.rs
@@ -3,14 +3,7 @@
 
 use zerocopy::{byteorder::little_endian as le, *};
 
-#[cfg(feature = "serde")]
-use super::utils::serde_wrappers;
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct TcbVersionMilanGenoa {
     pub boot_loader: u8,
@@ -21,7 +14,6 @@ pub struct TcbVersionMilanGenoa {
 }
 
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct TcbVersionTurin {
     pub fmc: u8,
@@ -33,7 +25,6 @@ pub struct TcbVersionTurin {
 }
 
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Default, Immutable)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct TcbVersionRaw {
     pub raw: [u8; 8],
@@ -48,14 +39,10 @@ impl TcbVersionRaw {
 }
 
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Immutable)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct Signature {
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub r: [u8; 72],
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub s: [u8; 72],
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     reserved: [u8; 512 - 144],
 }
 
@@ -63,19 +50,15 @@ pub struct Signature {
 ///
 /// See AMD SEV-SNP ABI Specification, Table 23: ATTESTATION_REPORT Structure.
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Immutable)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct AttestationReport {
     /// Version number of this attestation report. Set to 0x03 for this specification.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u32"))]
     pub version: le::U32, // 0x000
 
     /// The guest SVN (Security Version Number).
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u32"))]
     pub guest_svn: le::U32, // 0x004
 
     /// The guest policy. See Table 10 for a description of the guest policy structure.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u64"))]
     pub policy: le::U64, // 0x008
 
     /// The family ID provided at launch.
@@ -89,18 +72,15 @@ pub struct AttestationReport {
     /// For a guest-requested attestation report (MSG_REPORT_REQ), this field contains
     /// the value 0-3. A host-requested attestation report (SNP_HV_REPORT_REQ) will
     /// have a value of 0xFFFFFFFF.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u32"))]
     pub vmpl: le::U32, // 0x030
 
     /// The signature algorithm used to sign this report. See Chapter 10 for encodings.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u32"))]
     pub signature_algo: le::U32, // 0x034
 
     /// Current TCB (Trusted Computing Base) version.
     pub platform_version: TcbVersionRaw, // 0x038
 
     /// Information about the platform. See Table 24.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u64"))]
     pub platform_info: le::U64, // 0x040
 
     /// Flags field containing:
@@ -110,31 +90,25 @@ pub struct AttestationReport {
     /// - Bit 1 (MASK_CHIP_KEY): The value of MaskChipKey
     /// - Bit 0 (AUTHOR_KEY_EN): Indicates that the digest of the author key is present
     ///   in AUTHOR_KEY_DIGEST. Set to the value of GCTX.AuthorKeyEn.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u32"))]
     pub flags: le::U32, // 0x048
 
     /// Reserved. Must be zero.
-    #[cfg_attr(feature = "serde", serde(with = "serde_wrappers::le_u32"))]
     pub reserved0: le::U32, // 0x04C
 
     /// Guest-provided data if REQUEST_SOURCE is guest, otherwise zero-filled by firmware.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub report_data: [u8; 64], // 0x050
 
     /// The measurement calculated at launch.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub measurement: [u8; 48], // 0x090
 
     /// Data provided by the hypervisor at launch.
     pub host_data: [u8; 32], // 0x0C0
 
     /// SHA-384 digest of the ID public key that signed the ID block provided in SNP_LAUNCH_FINISH.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub id_key_digest: [u8; 48], // 0x0E0
 
     /// SHA-384 digest of the Author public key that certified the ID key, if provided
     /// in SNP_LAUNCH_FINISH. Zeroes if AUTHOR_KEY_EN is 1.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub author_key_digest: [u8; 48], // 0x110
 
     /// Report ID of this guest.
@@ -156,12 +130,10 @@ pub struct AttestationReport {
     pub cpuid_step: u8, // 0x18A
 
     /// Reserved.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub reserved1: [u8; 21], // 0x18B
 
     /// If MaskChipId is set to 0, identifier unique to the chip as output by GET_ID.
     /// Otherwise, set to 0h.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub chip_id: [u8; 64], // 0x1A0
 
     /// Committed TCB version.
@@ -195,7 +167,6 @@ pub struct AttestationReport {
     pub launch_tcb: TcbVersionRaw, // 0x1F0
 
     /// Reserved.
-    #[cfg_attr(feature = "serde", serde(with = "serde_big_array::BigArray"))]
     pub reserved4: [u8; 168], // 0x1F8
 
     /// Signature of bytes 0x00 to 0x29F inclusive of this report.

--- a/src/snp/utils.rs
+++ b/src/snp/utils.rs
@@ -1,32 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#[cfg(feature = "serde")]
-pub mod serde_wrappers {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use zerocopy::byteorder::little_endian as le;
-
-    pub mod le_u32 {
-        use super::*;
-        pub fn serialize<S: Serializer>(val: &le::U32, s: S) -> Result<S::Ok, S::Error> {
-            val.get().serialize(s)
-        }
-        pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<le::U32, D::Error> {
-            u32::deserialize(d).map(le::U32::new)
-        }
-    }
-
-    pub mod le_u64 {
-        use super::*;
-        pub fn serialize<S: Serializer>(val: &le::U64, s: S) -> Result<S::Ok, S::Error> {
-            val.get().serialize(s)
-        }
-        pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<le::U64, D::Error> {
-            u64::deserialize(d).map(le::U64::new)
-        }
-    }
-}
-
 /// SEV-SNP OID extensions for VCEK certificate verification
 /// These OIDs are used to extract TCB values from X.509 certificate extensions
 pub(crate) enum Oid {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! WASM bindings for SEV-SNP attestation verification.
+//!
+//! Provides JavaScript-facing functions via `wasm-bindgen` for use in
+//! browser and Node.js environments.
+
+use wasm_bindgen::prelude::*;
+use zerocopy::FromBytes;
+
+use crate::{AttestationReport, SevVerifier};
+
+/// Initialize the WASM module with panic hook and logging.
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+    wasm_logger::init(wasm_logger::Config::default());
+}
+
+/// JavaScript-facing verification function.
+///
+/// Accepts the raw attestation report bytes (1184 bytes) as a `Uint8Array`,
+/// fetches the certificate chain from AMD KDS, and verifies the report.
+#[wasm_bindgen]
+pub async fn verify_attestation_report(attestation_report_bytes: &[u8]) -> Result<(), String> {
+    let attestation_report = AttestationReport::read_from_bytes(attestation_report_bytes)
+        .map_err(|e| format!("Failed to parse attestation report: {:?}", e))?;
+
+    let mut verifier = SevVerifier::new()
+        .await
+        .map_err(|e| format!("Failed to initialize verifier: {}", e))?;
+    verifier
+        .verify_attestation(&attestation_report)
+        .await
+        .map_err(|e| format!("Verification failed: {:?}", e))
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use tee_attestation_verification_lib::snp::verify::ChainVerification;
-#[cfg(any(target_family = "wasm", feature = "online"))]
+#[cfg(feature = "kds")]
 use tee_attestation_verification_lib::SevVerifier;
 use tee_attestation_verification_lib::{certificate_from_pem, AttestationReport};
 use zerocopy::FromBytes;
@@ -147,7 +147,7 @@ pub async fn test_verify_attestation_suite_async() {
     }
 }
 
-#[cfg(all(feature = "online", async_crypto))]
+#[cfg(all(feature = "kds", async_crypto))]
 pub async fn verify_attestation_bytes(bytes: &[u8]) -> Result<(), String> {
     let attestation_report = AttestationReport::read_from_bytes(bytes)
         .map_err(|e| format!("Failed to read attestation report: {:?}", e))?;
@@ -162,17 +162,17 @@ pub async fn verify_attestation_bytes(bytes: &[u8]) -> Result<(), String> {
         .map_err(|e| format!("Verification call failed: {:?}", e))
 }
 
-#[cfg(all(feature = "online", async_crypto))]
+#[cfg(all(feature = "kds", async_crypto))]
 pub async fn verify_milan_attestation() -> Result<(), String> {
     verify_attestation_bytes(MILAN_ATTESTATION).await
 }
 
-#[cfg(all(feature = "online", async_crypto))]
+#[cfg(all(feature = "kds", async_crypto))]
 pub async fn verify_genoa_attestation() -> Result<(), String> {
     verify_attestation_bytes(GENOA_ATTESTATION).await
 }
 
-#[cfg(all(feature = "online", async_crypto))]
+#[cfg(all(feature = "kds", async_crypto))]
 pub async fn verify_turin_attestation() -> Result<(), String> {
     verify_attestation_bytes(TURIN_ATTESTATION).await
 }

--- a/tests/tests_native.rs
+++ b/tests/tests_native.rs
@@ -17,55 +17,53 @@ pub fn init_logger() {
     });
 }
 
-#[cfg(feature = "online")]
-mod online {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_verify_milan_attestation() {
-        init_logger();
-        common::verify_milan_attestation()
-            .await
-            .expect("Verification call failed");
-    }
-
-    #[tokio::test]
-    async fn test_verify_genoa_attestation() {
-        init_logger();
-        common::verify_genoa_attestation()
-            .await
-            .expect("Verification call failed");
-    }
-
-    #[tokio::test]
-    async fn test_verify_turin_attestation() {
-        init_logger();
-        common::verify_turin_attestation()
-            .await
-            .expect("Verification call failed");
-    }
-}
-
-/// Offline verification tests (sync, uses pinned ARKs)
-#[cfg(sync_crypto)]
-mod offline {
-    use super::*;
-
-    #[test]
-    fn test_suite() {
-        init_logger();
-        common::test_verify_attestation_suite();
-    }
-}
-
-/// Offline verification tests (async, uses pinned ARKs)
 #[cfg(async_crypto)]
-mod offline_async {
+mod r#async {
     use super::*;
 
     #[tokio::test]
     async fn test_suite() {
         init_logger();
         common::test_verify_attestation_suite_async().await;
+    }
+
+    #[cfg(feature = "kds")]
+    mod kds {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_verify_milan_attestation() {
+            init_logger();
+            common::verify_milan_attestation()
+                .await
+                .expect("Verification call failed");
+        }
+
+        #[tokio::test]
+        async fn test_verify_genoa_attestation() {
+            init_logger();
+            common::verify_genoa_attestation()
+                .await
+                .expect("Verification call failed");
+        }
+
+        #[tokio::test]
+        async fn test_verify_turin_attestation() {
+            init_logger();
+            common::verify_turin_attestation()
+                .await
+                .expect("Verification call failed");
+        }
+    }
+}
+
+#[cfg(sync_crypto)]
+mod sync {
+    use super::*;
+
+    #[test]
+    fn test_suite() {
+        init_logger();
+        common::test_verify_attestation_suite();
     }
 }

--- a/tests/tests_node.rs
+++ b/tests/tests_node.rs
@@ -24,39 +24,8 @@ fn init_logger() {
     });
 }
 
-/// Online verification tests (async, fetches certs from AMD KDS)
-#[cfg(feature = "online")]
-mod online {
-    use super::*;
-
-    #[wasm_bindgen_test]
-    async fn test_verify_milan_attestation() {
-        init_logger();
-        common::verify_milan_attestation()
-            .await
-            .expect("Verification call failed");
-    }
-
-    #[wasm_bindgen_test]
-    async fn test_verify_genoa_attestation() {
-        init_logger();
-        common::verify_genoa_attestation()
-            .await
-            .expect("Verification call failed");
-    }
-
-    #[wasm_bindgen_test]
-    async fn test_verify_turin_attestation() {
-        init_logger();
-        common::verify_turin_attestation()
-            .await
-            .expect("Verification call failed");
-    }
-}
-
-/// Offline verification tests (async, uses explicit collateral)
 #[cfg(async_crypto)]
-mod offline_async {
+mod r#async {
     use super::*;
 
     #[wasm_bindgen_test]
@@ -64,11 +33,39 @@ mod offline_async {
         init_logger();
         common::test_verify_attestation_suite_async().await;
     }
+
+    #[cfg(feature = "kds")]
+    mod kds {
+        use super::*;
+
+        #[wasm_bindgen_test]
+        async fn test_verify_milan_attestation() {
+            init_logger();
+            common::verify_milan_attestation()
+                .await
+                .expect("Verification call failed");
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_verify_genoa_attestation() {
+            init_logger();
+            common::verify_genoa_attestation()
+                .await
+                .expect("Verification call failed");
+        }
+
+        #[wasm_bindgen_test]
+        async fn test_verify_turin_attestation() {
+            init_logger();
+            common::verify_turin_attestation()
+                .await
+                .expect("Verification call failed");
+        }
+    }
 }
 
-/// Offline verification tests (sync, uses pinned ARKs)
 #[cfg(sync_crypto)]
-mod offline {
+mod sync {
     use super::*;
 
     #[wasm_bindgen_test]


### PR DESCRIPTION
- Drop serde entirely. The AttestationReport is a fixed-layout #[repr(C)] struct parsed via zerocopy::FromBytes — JSON serialization was unused by all verification flows. Removed serde, serde_json, serde-big-array deps and all conditional Serialize/Deserialize derives. The WASM entrypoint now accepts &[u8] (Uint8Array in JS) instead of a JSON string.

- Rename "online" feature to "kds". Clarifies that the feature gates AMD Key Distribution Service certificate fetching, not a vague "online" mode. kds is now a uniform opt-in across all targets (including wasm32, where curl/tokio deps are silently skipped by Cargo since fetching uses globalThis.fetch).

- Move WASM bindings from src/lib.rs to src/wasm.rs, gated on cfg(all(target_arch = "wasm32", feature = "kds")).

- Restructure test modules: offline/offline_async renamed to sync/async, with kds tests nested inside async. CI updated to test kds across all backend permutations.

Addresses #28 #30 