### PR TITLE
Release workflow needs checkout to push release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare_release.outputs.commit_sha }}
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The create-release action failed as it didn't have any info of where to push the release.
Two options exist, first you can pass `--repo` which encodes this explicitly, or you can checkout the repo.

As we may want to do reproducible build checking in the future (in which case we need to have it checked out), and to preserve parity with the 'standard' workflows (at the very least CCF uses checkout) this PR should fix the issue.