### PR TITLE
Documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,28 @@ jobs:
         run: |
           cargo fmt -- --check
 
+  docs-build:
+    name: Docs build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install rust
+        run: |
+          rustup update stable && rustup default stable
+
+      - name: Setup WASM tooling
+        run: |
+          rustup target add wasm32-unknown-unknown
+
+      - name: Native build docs
+        run: |
+          cargo doc
+
+      - name: WASM build docs
+        run: |
+          cargo doc --target wasm32-unknown-unknown
+
   wasm-build:
     name: WASM build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [0.1.1]
 
-[0.1.1](https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-0.1.1)
+[0.1.1]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-0.1.1
 
 - If multiple backends are enabled, choose the backend appropriate to the target architecture, e.g. OpenSSL on native, WebCrypto on WASM (#44)
 
 ## [0.1.0]
 
-[0.1.0](https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-0.1.0)
+[0.1.0]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-0.1.0
 
 - Initial development release of the TEE attestation verification library.
 - Supports native Rust consumers with the `crypto_openssl` and `crypto_pure_rust` backends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.1.0
+## [0.1.1]
+
+[0.1.1](https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-0.1.1)
+
+- If multiple backends are enabled, choose the backend appropriate to the target architecture, e.g. OpenSSL on native, WebCrypto on WASM (#44)
+
+## [0.1.0]
+
+[0.1.0](https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-0.1.0)
 
 - Initial development release of the TEE attestation verification library.
 - Supports native Rust consumers with the `crypto_openssl` and `crypto_pure_rust` backends.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-lib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "console_error_panic_hook",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ description = "WASM-compatible library for SEV-SNP verification and related type
 authors = ["Cameron Baird"]
 license = "MIT"
 
+[package.metadata.docs.rs]
+features = ["crypto_pure_rust", "kds"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Cameron Baird"]
 license = "MIT"
 
 [package.metadata.docs.rs]
-features = ["crypto_pure_rust", "kds"]
+features = ["crypto_openssl", "crypto_webcrypto", "kds"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [lib]
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [features]
-# At least one crypto backend must be enabled.
+default = ["crypto_openssl", "crypto_webcrypto"]
 crypto_openssl = ["dep:foreign-types", "dep:openssl", "dep:openssl-sys"]
 crypto_pure_rust = ["dep:ecdsa", "dep:p384", "dep:rsa", "dep:sha2", "dep:x509-cert"]
 crypto_webcrypto = ["dep:x509-cert"]
@@ -39,8 +39,6 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 [dependencies]
 # Crypto
 foreign-types = { version = "0.3", optional = true }
-openssl = { version = "0.10", optional = true }
-openssl-sys = { version = "0.9", optional = true }
 ecdsa = { version = "0.16", features = ["der", "verifying"], optional = true }
 p384 = { version = "0.13", features = ["ecdsa"], optional = true}
 rsa = { version = "0.9", optional = true }
@@ -51,6 +49,13 @@ zerocopy = {version = "0.8.31", features = ["derive"]}
 # KDS (online certificate fetching) dependencies
 log = { version = "0.4" }
 
+# Native deps
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+openssl = { version = "0.10", optional = true }
+openssl-sys = { version = "0.9", optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true}
+curl = { version = "0.4", optional = true }
+
 # WASM deps
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"
@@ -59,8 +64,3 @@ js-sys = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 console_error_panic_hook = "0.1"
 wasm-logger = "0.2"
-
-# Native CLI deps
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true}
-curl = { version = "0.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-lib"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
 keywords = ["confidentiality", "sev-snp", "tpm"]

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ cargo build --target wasm32-unknown-unknown --no-default-features --features "cr
 - **Signature Validation**: Validates the attestation report signature was signed by the VCEK
 - **TCB Verification**: Confirms that the TCB values in the attestation report match the VCEK's X.509 v3 extensions.
 
+## Docs
+Docs are available locally by running:
+- `cargo doc` for native docs
+- `cargo doc --target wasm32-unknown-unknown` for WASM builds
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ A minimal-external-dependencies, portable and safe library for verifying a TEE a
 
 ## Crypto Backends
 
-At least one crypto backend must be enabled, with `crypto_pure_rust` being used as a fallback if no alternatives are available:
+At least one target-compatible crypto backend must be enabled.
+If multiple backends are enabled, the target-compatible backend is selected with `crypto_openssl` and `crypto_webcrypto` preferred over `crypto_pure_rust`.
 
 | Feature | Platforms | sync | async | Dependencies |
 |---|---|---|---|---|
 | `crypto_openssl` | Native | ✓ | ✓ | OpenSSL |
 | `crypto_webcrypto` | WASM only | | ✓ | WebCrypto API |
-| `crypto_pure_rust` | Native, WASM | ✓ | ✓ | Pure Rust (`p384`, `rsa`, `sha2`) |
+| `crypto_pure_rust` | Native, WASM | ✓ | ✓ | Pure Rust (`p384`, `rsa`, `sha2`); selected when enabled and no target-preferred backend is enabled |
 
 ## Optional Features
 
@@ -87,7 +88,7 @@ Download the matching GitHub release asset for your chosen `tav-<crate-version>`
 Build the library for `wasm32` with the WebCrypto backend:
 
 ```bash
-wasm-pack build --target web -- --no-default-features --features "crypto_webcrypto,kds"
+wasm-pack build --target web --no-default-features --features "crypto_webcrypto,kds"
 ```
 
 For a plain Cargo build targeting `wasm32-unknown-unknown`:
@@ -100,7 +101,7 @@ cargo build --target wasm32-unknown-unknown --no-default-features --features "cr
 
 - **Certificate Validation**: Verifies the certificate chain from the ARK through the ASK to the VCEK, and the ARK against a root-of-trust
 - **Signature Validation**: Validates the attestation report signature was signed by the VCEK
-- **TCB Verification**: Confirm that the TCB values in the attestation report match the VCEK's x509v3 extensions.
+- **TCB Verification**: Confirms that the TCB values in the attestation report match the VCEK's X.509 v3 extensions.
 
 ## Trademarks
 

--- a/build.rs
+++ b/build.rs
@@ -11,17 +11,6 @@ fn main() {
     let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
     // Allow both webcrypto and openssl to be enabled, and to choose the one which is supported on the target platform.
-    if target_arch == "wasm32" && !(has_webcrypto || has_pure_rust) {
-        panic!(
-          "On wasm32 targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled, enable one of them."
-      );
-    }
-    if target_arch != "wasm32" && !(has_openssl || has_pure_rust) {
-        panic!(
-            "On native targets, at least one of `crypto_openssl` or `crypto_pure_rust` must be enabled, enable one of them."
-        );
-    }
-
     let crypto_backend = if target_arch != "wasm32" {
         if has_openssl {
             "crypto_openssl"
@@ -29,7 +18,7 @@ fn main() {
             "crypto_pure_rust"
         } else {
             panic!(
-              "On native targets, at least one of `crypto_openssl` or `crypto_pure_rust` must be enabled, enable one of them."
+              "On native targets, at least one of `crypto_openssl` or `crypto_pure_rust` must be enabled."
             );
         }
     } else if target_arch == "wasm32" {
@@ -39,7 +28,7 @@ fn main() {
             "crypto_pure_rust"
         } else {
             panic!(
-              "On wasm32 targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled, enable one of them."
+              "On wasm32 targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled."
             );
         }
     } else {

--- a/build.rs
+++ b/build.rs
@@ -10,26 +10,40 @@ fn main() {
     let has_pure_rust = std::env::var_os("CARGO_FEATURE_CRYPTO_PURE_RUST").is_some();
     let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
-    if has_webcrypto && target_arch != "wasm32" {
+    // Allow both webcrypto and openssl to be enabled, and to choose the one which is supported on the target platform.
+    if target_arch == "wasm32" && !(has_webcrypto || has_pure_rust) {
         panic!(
-            "`crypto_webcrypto` is only supported on wasm32 targets, use `crypto_openssl` instead."
+          "On wasm32 targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled, enable one of them."
+      );
+    }
+    if target_arch != "wasm32" && !(has_openssl || has_pure_rust) {
+        panic!(
+            "On native targets, at least one of `crypto_openssl` or `crypto_pure_rust` must be enabled, enable one of them."
         );
     }
 
-    if has_openssl && target_arch == "wasm32" {
-        panic!(
-            "`crypto_openssl` is not supported on wasm32 targets, use `crypto_webcrypto` or `crypto_pure_rust` instead."
-        );
-    }
-
-    let crypto_backend = if has_openssl {
-        "crypto_openssl"
-    } else if has_webcrypto {
-        "crypto_webcrypto"
-    } else if has_pure_rust {
-        "crypto_pure_rust"
+    let crypto_backend = if target_arch != "wasm32" {
+        if has_openssl {
+            "crypto_openssl"
+        } else if has_pure_rust {
+            "crypto_pure_rust"
+        } else {
+            panic!(
+              "On native targets, at least one of `crypto_openssl` or `crypto_pure_rust` must be enabled, enable one of them."
+            );
+        }
+    } else if target_arch == "wasm32" {
+        if has_webcrypto {
+            "crypto_webcrypto"
+        } else if has_pure_rust {
+            "crypto_pure_rust"
+        } else {
+            panic!(
+              "On wasm32 targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled, enable one of them."
+            );
+        }
     } else {
-        panic!("At least one crypto backend must be enabled, enable one of `crypto_openssl`, `crypto_webcrypto` or `crypto_pure_rust`.")
+        panic!("Unsupported target architecture: {target_arch}");
     };
 
     let backend_map = std::collections::BTreeMap::from([

--- a/demos/web-verify-kernel/README.md
+++ b/demos/web-verify-kernel/README.md
@@ -49,14 +49,15 @@ These are mirrors of upstream files in `tests/test_data/` and
 
 A successful result means the page has verified:
 
-- the ARK → ASK → VCEK certificate chain, and
-- the attestation report signature against the VCEK.
+- that the supplied ARK public key matches the pinned AMD root for the report's
+  processor generation,
+- the ARK → ASK → VCEK certificate chain,
+- the attestation report signature against the VCEK, and
+- report/VCEK TCB extension matching.
 
 It does **not** check:
 
-- that the supplied ARK is a genuine AMD root (the demo uses whatever ARK
-  you provide — see `src/pinned_arks/` for the pinned roots),
-- TCB freshness,
+- TCB freshness or revocation status,
 - the debug or single-socket policy bits,
 - whether `measurement` or `report_data` match any expected value.
 

--- a/src/certificate_chain.rs
+++ b/src/certificate_chain.rs
@@ -24,7 +24,7 @@ pub struct Chain {
     pub ask: Certificate,
 }
 
-/// AMD certificate chain representation for SEV-SNP verification
+/// AMD certificate manager for SEV-SNP verification.
 pub struct AmdCertificates {
     pub chains_cache: Vec<(snp::model::Generation, Chain)>,
     /// Versioned Chip Endorsement Key (VCEK) certificates by processor model
@@ -34,12 +34,19 @@ pub struct AmdCertificates {
 }
 
 impl AmdCertificates {
-    /// Create a new AmdCertificates by fetching ARK and ASK from KDS
+    /// Creates a new KDS-backed certificate manager.
+    ///
+    /// Certificate chains and VCEKs are fetched lazily when verification needs
+    /// them.
     pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {
         Self::with_cache(false).await
     }
 
-    /// Create a new AmdCertificates with caching enabled
+    /// Creates a new KDS-backed certificate manager with optional KDS fetcher caching.
+    ///
+    /// Certificate chains and VCEKs are still cached by this manager after they
+    /// are fetched; `use_cache` controls whether the underlying KDS fetcher uses
+    /// its own cache.
     pub async fn with_cache(use_cache: bool) -> Result<Self, Box<dyn std::error::Error>> {
         // Create fetcher
         let fetcher = if use_cache {

--- a/src/crypto/crypto_openssl.rs
+++ b/src/crypto/crypto_openssl.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! Native OpenSSL-backed cryptographic backend.
+//!
+//! This backend uses OpenSSL for X.509 certificate parsing and encoding,
+//! certificate-chain verification, and SEV-SNP attestation report signature
+//! verification. It is the native backend selected when `crypto_openssl` is
+//! enabled for a non-`wasm32` target.
+
 use foreign_types::ForeignType;
 use openssl::asn1::Asn1Object;
 use openssl::ecdsa::EcdsaSig;

--- a/src/crypto/crypto_pure_rust.rs
+++ b/src/crypto/crypto_pure_rust.rs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! Portable pure-Rust cryptographic backend.
+//!
+//! This backend is selected when `crypto_pure_rust` is enabled and no
+//! target-preferred backend is enabled. It uses pure-Rust crates for X.509
+//! certificate parsing, certificate-chain signature checks, and SEV-SNP
+//! attestation report signature verification.
+
 use p384::ecdsa::VerifyingKey as EcdsaVerifyingKey;
 use rsa::{
     pkcs8::DecodePublicKey,

--- a/src/crypto/crypto_webcrypto.rs
+++ b/src/crypto/crypto_webcrypto.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-#![cfg(all(target_arch = "wasm32", feature = "crypto_webcrypto"))]
-
 use js_sys::{Array, Object, Promise, Reflect, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;

--- a/src/crypto/crypto_webcrypto.rs
+++ b/src/crypto/crypto_webcrypto.rs
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! WASM WebCrypto-backed cryptographic backend.
+//!
+//! This backend uses the host runtime's `globalThis.crypto.subtle` API for
+//! asynchronous certificate-chain and SEV-SNP attestation report signature
+//! verification. Certificate parsing, encoding, and extension inspection use
+//! the shared pure-Rust X.509 parser. The runtime must provide WebCrypto with
+//! RSA-PSS/SHA-384 and ECDSA P-384/SHA-384 verification support.
+
 use js_sys::{Array, Object, Promise, Reflect, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -108,13 +108,13 @@ where
     }
 }
 
-#[cfg(feature = "crypto_openssl")]
+#[cfg(crypto_backend = "crypto_openssl")]
 pub(crate) mod crypto_openssl;
-#[cfg(feature = "crypto_pure_rust")]
+#[cfg(crypto_backend = "crypto_pure_rust")]
 pub(crate) mod crypto_pure_rust;
-#[cfg(feature = "crypto_webcrypto")]
+#[cfg(crypto_backend = "crypto_webcrypto")]
 pub(crate) mod crypto_webcrypto;
-#[cfg(any(feature = "crypto_pure_rust", feature = "crypto_webcrypto"))]
+#[cfg(any(crypto_backend = "crypto_pure_rust", crypto_backend = "crypto_webcrypto"))]
 mod x509_certificate;
 
 #[cfg(crypto_backend = "crypto_openssl")]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -114,7 +114,10 @@ pub(crate) mod crypto_openssl;
 pub(crate) mod crypto_pure_rust;
 #[cfg(crypto_backend = "crypto_webcrypto")]
 pub(crate) mod crypto_webcrypto;
-#[cfg(any(crypto_backend = "crypto_pure_rust", crypto_backend = "crypto_webcrypto"))]
+#[cfg(any(
+    crypto_backend = "crypto_pure_rust",
+    crypto_backend = "crypto_webcrypto"
+))]
 mod x509_certificate;
 
 #[cfg(crypto_backend = "crypto_openssl")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,57 @@
 
 //! Portable TEE attestation verification library.
 //!
-//! Supports SEV-SNP attestation verification with pluggable crypto backends
-//! (`crypto_openssl`, `crypto_pure_rust`, `crypto_webcrypto`) and optional
-//! online certificate fetching from AMD KDS (`kds` feature).
+//! This crate verifies AMD SEV-SNP attestation reports and certificate
+//! collateral. It supports native and WASM environments through selectable
+//! crypto backends.
+//!
+//! # Feature flags
+//!
+//! At least one crypto backend feature must be enabled:
+//!
+//! - `crypto_openssl`: native OpenSSL-backed verification.
+//! - `crypto_pure_rust`: native or WASM-compatible pure Rust verification.
+//! - `crypto_webcrypto`: WASM WebCrypto-backed verification.
+//! - `kds`: enables certificate fetching from AMD KDS.
+//!
+//! # Usage
+//!
+//! Use [`snp::report`] and [`AttestationReport`] to parse and inspect raw
+//! SEV-SNP attestation reports. Use [`snp::verify`] to verify reports with
+//! caller-provided certificate collateral. Use [`snp::ffi`] for FFI and
+//! WASM-oriented consumers; the `snp::ffi::wasm` submodule contains the
+//! caller-provided-certificate WASM API when building for `wasm32`.
+//!
+//! ```no_run
+//! use tee_attestation_verification_lib::snp::verify::{self, ChainVerification};
+//! use tee_attestation_verification_lib::{certificate_from_pem, AttestationReport};
+//! use zerocopy::FromBytes;
+//!
+//! # async fn example<'a>(
+//! #     attestation_bytes: &'a [u8],
+//! #     vcek_pem: &'a [u8],
+//! #     ask_pem: &'a [u8],
+//! # ) -> Result<(), Box<dyn std::error::Error + 'a>> {
+//! let attestation_report = AttestationReport::read_from_bytes(attestation_bytes)?;
+//! let vcek = certificate_from_pem(vcek_pem)?;
+//! let ask = certificate_from_pem(ask_pem)?;
+//!
+//! verify::asynchronous::verify_attestation(
+//!     &attestation_report,
+//!     &vcek,
+//!     &ChainVerification::WithPinnedArk { ask: &ask },
+//! )
+//! .await?;
+//! # Ok(())
+//! # }
+//! ```
 
 pub(crate) mod crypto;
+/// Pinned AMD Root Key (ARK) certificates for offline verification.
 pub mod pinned_arks;
+/// AMD SEV-SNP attestation report types, verification APIs, and FFI bindings.
 pub mod snp;
+/// Hex encoding and decoding helpers.
 pub mod utils;
 
 use crypto::{CertificateBackend, Crypto};
@@ -17,10 +61,18 @@ use crypto::{CertificateBackend, Crypto};
 pub use crypto::Certificate;
 pub use snp::report::AttestationReport;
 
+/// Parses a PEM-encoded X.509 certificate using the enabled crypto backend.
+///
+/// The returned [`Certificate`] can be passed to the SEV-SNP verification APIs
+/// in [`snp::verify`].
 pub fn certificate_from_pem(pem: &[u8]) -> Result<Certificate, Box<dyn std::error::Error>> {
     Crypto::from_pem(pem)
 }
 
+/// Parses a DER-encoded X.509 certificate using the enabled crypto backend.
+///
+/// The returned [`Certificate`] can be passed to the SEV-SNP verification APIs
+/// in [`snp::verify`].
 pub fn certificate_from_der(der: &[u8]) -> Result<Certificate, Box<dyn std::error::Error>> {
     Crypto::from_der(der)
 }
@@ -30,6 +82,7 @@ mod certificate_chain;
 #[cfg(feature = "kds")]
 mod kds;
 #[cfg(feature = "kds")]
+/// KDS-backed SEV-SNP verifier that fetches AMD certificate collateral.
 pub mod sev_verification;
 #[cfg(feature = "kds")]
 pub use certificate_chain::AmdCertificates;
@@ -37,6 +90,8 @@ pub use certificate_chain::AmdCertificates;
 pub use sev_verification::SevVerifier;
 
 #[cfg(all(target_arch = "wasm32", feature = "kds"))]
+/// KDS-fetching WASM API, distinct from the caller-provided-certificate
+/// `snp::ffi::wasm` API.
 pub mod wasm;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,20 +9,23 @@
 //!
 //! # Feature flags
 //!
-//! At least one crypto backend feature must be enabled:
+//! At least one target-compatible crypto backend feature must be enabled.
+//!
+//! ## Crypto backends
 //!
 //! - `crypto_openssl`: native OpenSSL-backed verification.
 //! - `crypto_webcrypto`: WASM WebCrypto-backed verification.
-//! - `crypto_pure_rust`: native or WASM-compatible pure Rust verification.
+//! - `crypto_pure_rust`: portable pure-Rust verification, selected when no target-preferred backend is enabled.
+//!
+//! ## Additional features
+//!
 //! - `kds`: enables certificate fetching from AMD KDS.
 //!
 //! # Usage
 //!
-//! Use [`snp::report`] and [`AttestationReport`] to parse and inspect raw
-//! SEV-SNP attestation reports. Use [`snp::verify`] to verify reports with
-//! caller-provided certificate collateral. Use [`snp::ffi`] for FFI and
-//! WASM-oriented consumers; the `snp::ffi::wasm` submodule contains the
-//! caller-provided-certificate WASM API when building for `wasm32`.
+//! [`AttestationReport`] provides the parsing and inspection APIs for SEV-SNP attestation reports.
+//!
+//! [`snp::verify`] is used to verify reports using provided collateral.
 //!
 //! ```no_run
 //! use tee_attestation_verification_lib::snp::verify::{self, ChainVerification};
@@ -47,13 +50,14 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Use [`snp::ffi`] for FFI and WASM-oriented consumers; the `snp::ffi::wasm`
+//! submodule contains the caller-provided-certificate WASM API when building
+//! for `wasm32`.
 
 pub(crate) mod crypto;
-/// Pinned AMD Root Key (ARK) certificates for offline verification.
 pub mod pinned_arks;
-/// AMD SEV-SNP attestation report types, verification APIs, and FFI bindings.
 pub mod snp;
-/// Hex encoding and decoding helpers.
 pub mod utils;
 
 use crypto::{CertificateBackend, Crypto};
@@ -82,7 +86,6 @@ mod certificate_chain;
 #[cfg(feature = "kds")]
 mod kds;
 #[cfg(feature = "kds")]
-/// KDS-backed SEV-SNP verifier that fetches AMD certificate collateral.
 pub mod sev_verification;
 #[cfg(feature = "kds")]
 pub use certificate_chain::AmdCertificates;
@@ -90,8 +93,6 @@ pub use certificate_chain::AmdCertificates;
 pub use sev_verification::SevVerifier;
 
 #[cfg(all(target_arch = "wasm32", feature = "kds"))]
-/// KDS-fetching WASM API, distinct from the caller-provided-certificate
-/// `snp::ffi::wasm` API.
 pub mod wasm;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //! At least one crypto backend feature must be enabled:
 //!
 //! - `crypto_openssl`: native OpenSSL-backed verification.
-//! - `crypto_pure_rust`: native or WASM-compatible pure Rust verification.
 //! - `crypto_webcrypto`: WASM WebCrypto-backed verification.
+//! - `crypto_pure_rust`: native or WASM-compatible pure Rust verification.
 //! - `kds`: enables certificate fetching from AMD KDS.
 //!
 //! # Usage

--- a/src/sev_verification.rs
+++ b/src/sev_verification.rs
@@ -33,9 +33,9 @@ impl SevVerifier {
     }
 
     #[cfg(target_arch = "wasm32")]
-    /// Initialize wasm logging and panic hook once. Only available when the
-    /// `wasm` feature is enabled. No-op on non-wasm builds or when the feature
-    /// isn't enabled.
+    /// Initializes WASM logging and the panic hook once.
+    ///
+    /// This helper is only compiled for `wasm32` targets.
     fn init_wasm_logging() {
         {
             static INIT: std::sync::Once = std::sync::Once::new();

--- a/src/snp/ffi.rs
+++ b/src/snp/ffi.rs
@@ -6,8 +6,8 @@
 //! [`crate::snp::ffi::ErrorCode`] and [`crate::snp::ffi::VerifyError`] classify
 //! verification failures in a form suitable for non-Rust callers.
 //! Target-specific bindings live under submodules; the `wasm` submodule is
-//! compiled only for `wasm32` and exposes
-//! the caller-provided-certificate WebAssembly API.
+//! compiled only for `wasm32` and exposes the caller-provided-certificate
+//! WebAssembly API.
 //!
 //! A sync `verify_attestation` for C FFI consumers will be added alongside the
 //! C FFI bindings.
@@ -169,16 +169,9 @@ mod tests {
 pub mod wasm {
     //! `wasm_bindgen` bindings exposing verified SNP attestation reports to JS.
     //!
-    //! Build this crate for `wasm32` with the WebCrypto backend, then call
-    //! [`verify_attestation_async`] from JavaScript with raw report bytes and
-    //! PEM-encoded ARK, ASK, and VCEK certificates. On success, the function
-    //! returns a [`SnpAttestationReport`]. The only way to obtain that type is
-    //! through successful verification, so its accessor methods return fields
-    //! from a cryptographically verified report.
-    //!
-    //! ```sh
-    //! wasm-pack build --target web --no-default-features --features "crypto_webcrypto"
-    //! ```
+    //! SnpAttestationReport is opaque and can only be obtained through successful
+    //! verification with `verify_attestation_async`. Its accessor methods return
+    //! fields from the verified report bytes.
     //!
     //! See `demos/web-verify-kernel/README.md` in the repository for a runnable
     //! browser demo that uses these bindings.

--- a/src/snp/ffi.rs
+++ b/src/snp/ffi.rs
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! FFI types and bindings for SNP attestation verification.
+//! FFI types and target-specific bindings for SNP attestation verification.
 //!
-//! - [`ErrorCode`] and [`VerifyError`] classify verification failures and are
-//!   shared between all FFI surfaces.
-//! - [`wasm`] (only compiled on `wasm32`): exports a `wasm_bindgen` class
-//!   [`wasm::SnpAttestationReport`] returned by a successful
-//!   `verify_attestation_async`. Because the struct is only constructible via
-//!   successful verification, callers cannot inspect unverified reports.
+//! [`crate::snp::ffi::ErrorCode`] and [`crate::snp::ffi::VerifyError`] classify
+//! verification failures in a form suitable for non-Rust callers.
+//! Target-specific bindings live under submodules; the `wasm` submodule is
+//! compiled only for `wasm32` and exposes
+//! the caller-provided-certificate WebAssembly API.
 //!
 //! A sync `verify_attestation` for C FFI consumers will be added alongside the
 //! C FFI bindings.
@@ -32,11 +31,17 @@ use wasm_bindgen::prelude::*;
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCode {
+    /// Input bytes or certificate text could not be parsed.
     InvalidArgument = 1,
+    /// The report's processor family/model is not supported.
     UnsupportedProcessor = 101,
+    /// The selected or provided ARK certificate is not a valid trusted root.
     InvalidRootCertificate = 102,
+    /// The ARK → ASK → VCEK certificate chain could not be verified.
     CertificateChainError = 103,
+    /// The attestation report signature could not be verified with the VCEK.
     SignatureVerificationError = 104,
+    /// Report TCB values did not match the corresponding VCEK extensions.
     TcbVerificationError = 105,
 }
 
@@ -164,9 +169,19 @@ mod tests {
 pub mod wasm {
     //! `wasm_bindgen` bindings exposing verified SNP attestation reports to JS.
     //!
-    //! The only way to obtain a [`SnpAttestationReport`] is by calling
-    //! [`verify_attestation_async`], so all accessor methods are guaranteed to
-    //! return data from a cryptographically verified report.
+    //! Build this crate for `wasm32` with the WebCrypto backend, then call
+    //! [`verify_attestation_async`] from JavaScript with raw report bytes and
+    //! PEM-encoded ARK, ASK, and VCEK certificates. On success, the function
+    //! returns a [`SnpAttestationReport`]. The only way to obtain that type is
+    //! through successful verification, so its accessor methods return fields
+    //! from a cryptographically verified report.
+    //!
+    //! ```sh
+    //! wasm-pack build --target web --no-default-features --features "crypto_webcrypto"
+    //! ```
+    //!
+    //! See `demos/web-verify-kernel/README.md` in the repository for a runnable
+    //! browser demo that uses these bindings.
 
     use wasm_bindgen::prelude::*;
     use zerocopy::FromBytes;

--- a/src/snp/mod.rs
+++ b/src/snp/mod.rs
@@ -7,11 +7,8 @@
 //! [`crate::snp::report`], verification APIs in [`crate::snp::verify`], and
 //! FFI/WASM-oriented bindings in [`crate::snp::ffi`].
 
-/// FFI error types and target-specific bindings for SEV-SNP verification.
 pub mod ffi;
 pub(crate) mod model;
-/// SEV-SNP attestation report structures
 pub mod report;
 pub(crate) mod utils;
-/// SEV-SNP attestation verification with caller-provided certificates.
 pub mod verify;

--- a/src/snp/mod.rs
+++ b/src/snp/mod.rs
@@ -2,10 +2,6 @@
 // Licensed under the MIT License.
 
 //! AMD SEV-SNP attestation report types and verification APIs.
-//!
-//! This module contains the zero-copy report representation in
-//! [`crate::snp::report`], verification APIs in [`crate::snp::verify`], and
-//! FFI/WASM-oriented bindings in [`crate::snp::ffi`].
 
 pub mod ffi;
 pub(crate) mod model;

--- a/src/snp/mod.rs
+++ b/src/snp/mod.rs
@@ -1,8 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AMD SEV-SNP attestation report types and verification APIs.
+//!
+//! This module contains the zero-copy report representation in
+//! [`crate::snp::report`], verification APIs in [`crate::snp::verify`], and
+//! FFI/WASM-oriented bindings in [`crate::snp::ffi`].
+
+/// FFI error types and target-specific bindings for SEV-SNP verification.
 pub mod ffi;
 pub(crate) mod model;
+/// SEV-SNP attestation report structures
 pub mod report;
 pub(crate) mod utils;
+/// SEV-SNP attestation verification with caller-provided certificates.
 pub mod verify;

--- a/src/snp/report.rs
+++ b/src/snp/report.rs
@@ -6,6 +6,35 @@
 //! [`crate::snp::report::AttestationReport`] mirrors the AMD SEV-SNP ABI report
 //! layout and can be parsed directly from the raw 1184-byte report buffer using
 //! `zerocopy`'s [`zerocopy::FromBytes`] trait.
+//!
+//! # Examples
+//!
+//! Verify an attestation report before returning the authenticated claims to the caller:
+//!
+//! ```no_run
+//! use tee_attestation_verification_lib::snp::verify::{self, ChainVerification};
+//! use tee_attestation_verification_lib::{certificate_from_pem, AttestationReport};
+//! use zerocopy::FromBytes;
+//!
+//! # async fn example<'a>(
+//! #     attestation_bytes: &'a [u8],
+//! #     vcek_pem: &'a [u8],
+//! #     ask_pem: &'a [u8],
+//! # ) -> Result<AttestationReport, Box<dyn std::error::Error + 'a>> {
+//! let report = AttestationReport::read_from_bytes(attestation_bytes)?;
+//! let vcek = certificate_from_pem(vcek_pem)?;
+//! let ask = certificate_from_pem(ask_pem)?;
+//!
+//! verify::asynchronous::verify_attestation(
+//!     &report,
+//!     &vcek,
+//!     &ChainVerification::WithPinnedArk { ask: &ask },
+//! )
+//! .await?;
+//!
+//! # Ok(report)
+//! # }
+//! ```
 
 use zerocopy::{byteorder::little_endian as le, *};
 
@@ -239,7 +268,7 @@ pub struct Signature {
     reserved: [u8; 512 - 144],
 }
 
-/// SNP Attestation Report (0x4A0 = 1184 bytes).
+/// SEV-SNP attestation report (0x4A0 = 1184 bytes).
 ///
 /// See AMD SEV-SNP ABI Specification, Table 23: ATTESTATION_REPORT Structure.
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Immutable, KnownLayout, Unaligned)]
@@ -289,6 +318,10 @@ pub struct AttestationReport {
     pub reserved0: le::U32, // 0x04C
 
     /// Guest-provided data if REQUEST_SOURCE is guest, otherwise zero-filled by firmware.
+    ///
+    /// Verification authenticates this value as part of the signed report, but
+    /// callers are responsible for comparing it to their expected nonce,
+    /// challenge, public-key digest, or other application-specific context.
     pub report_data: [u8; 64], // 0x050
 
     /// The measurement calculated at launch.
@@ -301,7 +334,7 @@ pub struct AttestationReport {
     pub id_key_digest: [u8; 48], // 0x0E0
 
     /// SHA-384 digest of the Author public key that certified the ID key, if provided
-    /// in SNP_LAUNCH_FINISH. Zeroes if AUTHOR_KEY_EN is 1.
+    /// in SNP_LAUNCH_FINISH. Zeroes if AUTHOR_KEY_EN is 0.
     pub author_key_digest: [u8; 48], // 0x110
 
     /// Report ID of this guest.
@@ -374,12 +407,12 @@ impl AttestationReport {
         &bytes[..0x2A0]
     }
 
-    /// Decode the guest policy bitfield.
+    /// Returns the decoded guest policy bitfield.
     pub fn policy(&self) -> GuestPolicy {
         GuestPolicy::from_raw(self.policy.get())
     }
 
-    /// Decode the report flags bitfield.
+    /// Returns the decoded report flags bitfield.
     pub fn flags(&self) -> ReportFlags {
         ReportFlags::from_raw(self.flags.get())
     }

--- a/src/snp/report.rs
+++ b/src/snp/report.rs
@@ -7,7 +7,7 @@
 //! layout and can be parsed directly from the raw 1184-byte report buffer using
 //! `zerocopy`'s [`zerocopy::FromBytes`] trait.
 //!
-//! # Examples
+//! # Example
 //!
 //! Verify an attestation report before returning the authenticated claims to the caller:
 //!

--- a/src/snp/report.rs
+++ b/src/snp/report.rs
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! AMD SEV-SNP attestation report structures.
+//!
+//! [`crate::snp::report::AttestationReport`] mirrors the AMD SEV-SNP ABI report
+//! layout and can be parsed directly from the raw 1184-byte report buffer using
+//! `zerocopy`'s [`zerocopy::FromBytes`] trait.
+
 use zerocopy::{byteorder::little_endian as le, *};
 
 // ---------------------------------------------------------------------------
@@ -27,54 +33,67 @@ impl GuestPolicy {
     const CIPHERTEXT_HIDING_DRAM_BIT: u64 = 1 << 24;
     const PAGE_SWAP_DISABLE_BIT: u64 = 1 << 25;
 
+    /// Wraps the raw 64-bit guest policy field.
     pub fn from_raw(raw: u64) -> Self {
         Self(raw)
     }
 
+    /// Returns the raw 64-bit guest policy field.
     pub fn raw(&self) -> u64 {
         self.0
     }
 
+    /// Returns the minimum ABI minor version required by the guest.
     pub fn abi_minor(&self) -> u8 {
         (self.0 & Self::ABI_MINOR_MASK) as u8
     }
 
+    /// Returns the minimum ABI major version required by the guest.
     pub fn abi_major(&self) -> u8 {
         ((self.0 & Self::ABI_MAJOR_MASK) >> 8) as u8
     }
 
+    /// Returns whether simultaneous multithreading is allowed.
     pub fn smt(&self) -> bool {
         self.0 & Self::SMT_BIT != 0
     }
 
+    /// Returns whether association with a migration agent is allowed.
     pub fn migrate_ma(&self) -> bool {
         self.0 & Self::MIGRATE_MA_BIT != 0
     }
 
+    /// Returns whether debug mode is allowed.
     pub fn debug(&self) -> bool {
         self.0 & Self::DEBUG_BIT != 0
     }
 
+    /// Returns whether the guest must run on a single socket.
     pub fn single_socket(&self) -> bool {
         self.0 & Self::SINGLE_SOCKET_BIT != 0
     }
 
+    /// Returns whether CXL devices are allowed.
     pub fn cxl_allow(&self) -> bool {
         self.0 & Self::CXL_ALLOW_BIT != 0
     }
 
+    /// Returns whether 256-bit AES-XTS memory encryption is required.
     pub fn mem_aes_256_xts(&self) -> bool {
         self.0 & Self::MEM_AES_256_XTS_BIT != 0
     }
 
+    /// Returns whether RAPL is disabled.
     pub fn rapl_dis(&self) -> bool {
         self.0 & Self::RAPL_DIS_BIT != 0
     }
 
+    /// Returns whether ciphertext hiding for DRAM is enabled.
     pub fn ciphertext_hiding_dram(&self) -> bool {
         self.0 & Self::CIPHERTEXT_HIDING_DRAM_BIT != 0
     }
 
+    /// Returns whether page swapping is disabled.
     pub fn page_swap_disable(&self) -> bool {
         self.0 & Self::PAGE_SWAP_DISABLE_BIT != 0
     }
@@ -83,13 +102,18 @@ impl GuestPolicy {
 /// The key type used to sign the attestation report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SigningKey {
+    /// Versioned Chip Endorsement Key.
     Vcek,
+    /// Versioned Loaded Endorsement Key.
     Vlek,
+    /// No signing key is indicated.
     None,
+    /// Reserved signing-key encoding from the report.
     Reserved(u8),
 }
 
 impl SigningKey {
+    /// Decodes the raw signing-key field from report flags.
     pub fn from_raw(raw: u8) -> Self {
         match raw {
             0 => Self::Vcek,
@@ -99,6 +123,7 @@ impl SigningKey {
         }
     }
 
+    /// Returns the raw signing-key encoding.
     pub fn raw(&self) -> u8 {
         match self {
             Self::Vcek => 0,
@@ -122,22 +147,27 @@ impl ReportFlags {
     const MASK_CHIP_KEY_BIT: u32 = 1 << 1;
     const SIGNING_KEY_MASK: u32 = 0b111 << 2;
 
+    /// Wraps the raw 32-bit report flags field.
     pub fn from_raw(raw: u32) -> Self {
         Self(raw)
     }
 
+    /// Returns the raw 32-bit report flags field.
     pub fn raw(&self) -> u32 {
         self.0
     }
 
+    /// Returns whether the report includes an author key digest.
     pub fn author_key_en(&self) -> bool {
         self.0 & Self::AUTHOR_KEY_EN_BIT != 0
     }
 
+    /// Returns whether the chip ID is masked in the report.
     pub fn mask_chip_key(&self) -> bool {
         self.0 & Self::MASK_CHIP_KEY_BIT != 0
     }
 
+    /// Returns the decoded signing key used for the report.
     pub fn signing_key(&self) -> SigningKey {
         SigningKey::from_raw(((self.0 & Self::SIGNING_KEY_MASK) >> 2) as u8)
     }
@@ -147,45 +177,64 @@ impl ReportFlags {
 // TCB version types
 // ---------------------------------------------------------------------------
 
+/// TCB version layout used by Milan and Genoa processors.
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes)]
 #[repr(C)]
 pub struct TcbVersionMilanGenoa {
+    /// Boot loader security version number.
     pub boot_loader: u8,
+    /// TEE security version number.
     pub tee: u8,
     reserved: [u8; 4],
+    /// SNP firmware security version number.
     pub snp: u8,
+    /// Microcode security version number.
     pub microcode: u8,
 }
 
+/// TCB version layout used by Turin processors.
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes)]
 #[repr(C)]
 pub struct TcbVersionTurin {
+    /// Firmware microcontroller security version number.
     pub fmc: u8,
+    /// Boot loader security version number.
     pub boot_loader: u8,
+    /// TEE security version number.
     pub tee: u8,
+    /// SNP firmware security version number.
     pub snp: u8,
     reserved: [u8; 3],
+    /// Microcode security version number.
     pub microcode: u8,
 }
 
+/// Raw 8-byte TCB version field from an attestation report.
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Default, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct TcbVersionRaw {
+    /// Raw TCB bytes in report layout order.
     pub raw: [u8; 8],
 }
 impl TcbVersionRaw {
+    /// Interprets the raw bytes using the Milan/Genoa TCB layout.
     pub fn as_milan_genoa(&self) -> TcbVersionMilanGenoa {
         try_transmute!(*self).unwrap()
     }
+
+    /// Interprets the raw bytes using the Turin TCB layout.
     pub fn as_turin(&self) -> TcbVersionTurin {
         try_transmute!(*self).unwrap()
     }
 }
 
+/// ECDSA signature field from an SEV-SNP attestation report.
 #[derive(Debug, Clone, Copy, IntoBytes, FromBytes, Immutable, KnownLayout, Unaligned)]
 #[repr(C)]
 pub struct Signature {
+    /// Signature `r` component in the report's fixed-width encoding.
     pub r: [u8; 72],
+    /// Signature `s` component in the report's fixed-width encoding.
     pub s: [u8; 72],
     reserved: [u8; 512 - 144],
 }

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -1,15 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+//! SEV-SNP attestation verification with caller-provided certificates.
+//!
+//! The verification APIs identify the processor generation from the report,
+//! optionally verify the ARK → ASK → VCEK certificate chain, verify the report
+//! signature with the VCEK, and compare report TCB values against VCEK
+//! certificate extensions. Use the `sync` module with sync-capable crypto
+//! backends and [`crate::snp::verify::asynchronous`] with async-capable crypto
+//! backends.
+
 use crate::crypto::{Certificate, CertificateBackend, Crypto};
 use crate::{snp, snp::utils::Oid, AttestationReport};
 
+/// Error returned when SEV-SNP attestation verification fails.
 #[derive(Debug)]
 pub enum VerificationError {
+    /// The report's processor family/model is not supported by this crate.
     UnsupportedProcessor(String),
+    /// The selected or provided ARK certificate is not a valid trusted root.
     InvalidRootCertificate(String),
+    /// The ARK → ASK → VCEK certificate chain could not be verified.
     CertificateChainError(String),
+    /// The attestation report signature could not be verified with the VCEK.
     SignatureVerificationError(String),
+    /// Report TCB values did not match the corresponding VCEK extensions.
     TcbVerificationError(String),
 }
 
@@ -27,21 +42,29 @@ impl std::fmt::Display for VerificationError {
 
 impl std::error::Error for VerificationError {}
 
-//ChainVerification::Skip skips chain verification and only verifies report signature + TCB using VCEK.
-//ChainVerification::WithPinnedArk verifies chain with pinned ARK for the processor model.
-//ChainVerification::WithProvidedArk verifies chain with caller-provided ARK after validating its public key matches pinned ARK.
+/// Certificate-chain verification mode for caller-provided certificates.
 pub enum ChainVerification<'a> {
+    /// Skip certificate-chain verification and only verify the report signature
+    /// and TCB values using the provided VCEK.
     Skip,
+    /// Verify the chain using the ASK provided by the caller and the pinned ARK
+    /// for the report's processor generation.
     WithPinnedArk {
+        /// AMD SEV Key (ASK) certificate.
         ask: &'a Certificate,
     },
+    /// Verify the chain using caller-provided ASK and ARK certificates after
+    /// confirming that the provided ARK public key matches the pinned ARK.
     WithProvidedArk {
+        /// AMD SEV Key (ASK) certificate.
         ask: &'a Certificate,
+        /// AMD Root Key (ARK) certificate.
         ark: &'a Certificate,
     },
 }
 
 #[cfg(sync_crypto)]
+/// Synchronous SEV-SNP attestation verification.
 pub mod sync {
     use crate::crypto::verifier::Sync as Verifier;
     use crate::crypto::{Certificate, Crypto, CryptoBackend};
@@ -49,6 +72,11 @@ pub mod sync {
 
     use super::{ark_matches_pinned, verify_tcb_values, ChainVerification, VerificationError};
 
+    /// Verifies an SEV-SNP attestation report using caller-provided certificates.
+    ///
+    /// Verification consists of processor-generation detection, certificate-chain
+    /// verification according to `chain_verification`, report signature
+    /// verification with `vcek`, and report/VCEK TCB extension matching.
     pub fn verify_attestation(
         attestation_report: &AttestationReport,
         vcek: &Certificate,
@@ -88,6 +116,7 @@ pub mod sync {
 }
 
 #[cfg(async_crypto)]
+/// Asynchronous SEV-SNP attestation verification.
 pub mod asynchronous {
     use crate::crypto::verifier::Async as Verifier;
     use crate::crypto::{AsyncCryptoBackend, Certificate, Crypto};
@@ -95,6 +124,11 @@ pub mod asynchronous {
 
     use super::{ark_matches_pinned, verify_tcb_values, ChainVerification, VerificationError};
 
+    /// Verifies an SEV-SNP attestation report using caller-provided certificates.
+    ///
+    /// Verification consists of processor-generation detection, certificate-chain
+    /// verification according to `chain_verification`, report signature
+    /// verification with `vcek`, and report/VCEK TCB extension matching.
     pub async fn verify_attestation(
         attestation_report: &AttestationReport,
         vcek: &Certificate,

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -13,9 +13,9 @@
 //! but callers should compare `report_data` to their expected nonce, challenge,
 //! public-key digest, or other application-specific context.
 //!
-//! The `sync` and `asyncronous` modules provide separate APIs for synchronous and asynchronous crypto
+//! The `sync` and `asyncronous` modules provide separate APIs for synchronous and asynchronous crypto backends.
 //!
-//! # Examples
+//! # Example
 //!
 //! Verify an attestation report before returning the authenticated claims to the caller:
 //!

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -13,7 +13,7 @@
 //! but callers should compare `report_data` to their expected nonce, challenge,
 //! public-key digest, or other application-specific context.
 //!
-//! The `sync` and `asyncronous` modules provide separate APIs for synchronous and asynchronous crypto backends.
+//! The `sync` and `asynchronous` modules provide separate APIs for synchronous and asynchronous crypto backends.
 //!
 //! # Example
 //!

--- a/src/snp/verify.rs
+++ b/src/snp/verify.rs
@@ -6,9 +6,43 @@
 //! The verification APIs identify the processor generation from the report,
 //! optionally verify the ARK → ASK → VCEK certificate chain, verify the report
 //! signature with the VCEK, and compare report TCB values against VCEK
-//! certificate extensions. Use the `sync` module with sync-capable crypto
-//! backends and [`crate::snp::verify::asynchronous`] with async-capable crypto
-//! backends.
+//! certificate extensions.
+//!
+//! Successful verification authenticates the signed report, including
+//! [`AttestationReport::report_data`](crate::AttestationReport::report_data),
+//! but callers should compare `report_data` to their expected nonce, challenge,
+//! public-key digest, or other application-specific context.
+//!
+//! The `sync` and `asyncronous` modules provide separate APIs for synchronous and asynchronous crypto
+//!
+//! # Examples
+//!
+//! Verify an attestation report before returning the authenticated claims to the caller:
+//!
+//! ```no_run
+//! use tee_attestation_verification_lib::snp::verify::{self, ChainVerification};
+//! use tee_attestation_verification_lib::{certificate_from_pem, AttestationReport};
+//! use zerocopy::FromBytes;
+//!
+//! # async fn example<'a>(
+//! #     attestation_bytes: &'a [u8],
+//! #     vcek_pem: &'a [u8],
+//! #     ask_pem: &'a [u8],
+//! # ) -> Result<AttestationReport, Box<dyn std::error::Error + 'a>> {
+//! let report = AttestationReport::read_from_bytes(attestation_bytes)?;
+//! let vcek = certificate_from_pem(vcek_pem)?;
+//! let ask = certificate_from_pem(ask_pem)?;
+//!
+//! verify::asynchronous::verify_attestation(
+//!     &report,
+//!     &vcek,
+//!     &ChainVerification::WithPinnedArk { ask: &ask },
+//! )
+//! .await?;
+//!
+//! # Ok(report)
+//! # }
+//! ```
 
 use crate::crypto::{Certificate, CertificateBackend, Crypto};
 use crate::{snp, snp::utils::Oid, AttestationReport};
@@ -76,7 +110,9 @@ pub mod sync {
     ///
     /// Verification consists of processor-generation detection, certificate-chain
     /// verification according to `chain_verification`, report signature
-    /// verification with `vcek`, and report/VCEK TCB extension matching.
+    /// verification with `vcek`, and report/VCEK TCB extension matching. Callers
+    /// must separately compare `attestation_report.report_data` to the expected
+    /// nonce, challenge, public-key digest, or other application-specific context.
     pub fn verify_attestation(
         attestation_report: &AttestationReport,
         vcek: &Certificate,
@@ -128,7 +164,9 @@ pub mod asynchronous {
     ///
     /// Verification consists of processor-generation detection, certificate-chain
     /// verification according to `chain_verification`, report signature
-    /// verification with `vcek`, and report/VCEK TCB extension matching.
+    /// verification with `vcek`, and report/VCEK TCB extension matching. Callers
+    /// must separately compare `attestation_report.report_data` to the expected
+    /// nonce, challenge, public-key digest, or other application-specific context.
     pub async fn verify_attestation(
         attestation_report: &AttestationReport,
         vcek: &Certificate,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,8 @@
+//! Hex encoding and decoding helpers.
+//!
+//! These helpers are small utilities used by verification error messages and
+//! callers that need to render or parse byte strings as hexadecimal text.
+
 fn b16_to_hex(b16: u8) -> char {
     const ASCI_0: u8 = b'0';
     const ASCI_A: u8 = b'a';
@@ -8,6 +13,7 @@ fn b16_to_hex(b16: u8) -> char {
     }
 }
 
+/// Encodes bytes as lowercase hexadecimal text.
 pub fn to_hex(bytes: &[u8]) -> String {
     let mut res = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
@@ -17,6 +23,10 @@ pub fn to_hex(bytes: &[u8]) -> String {
     res
 }
 
+/// Decodes hexadecimal text into bytes.
+///
+/// Returns an error if the input contains non-ASCII characters, has odd
+/// length, or contains characters that are not valid hexadecimal digits.
 pub fn from_hex(s: &str) -> Result<Vec<u8>, String> {
     if !s.is_ascii() {
         return Err("Hex string must contain only ASCII characters".to_string());


### PR DESCRIPTION
This PR adds docs for this repo.

The major functional change this required, was to change the behaviour when multiple backends are selected.
Specifically, if we have both `crypto_openssl` and `crypto_webcrypto` enabled, then the chosen backend is on the basis of the target (OpenSSL for native, and WebCrypto for WASM).

Otherwise it is only adding documentation and examples for each of the modules.