### PR TITLE
Expose cert splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 [1.0.1]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.1
 
-# Added
+### Added
 
-- Expose a WASM certificate bundle splitter.
+- Expose a WASM certificate bundle splitter. (#49)
 
 ## [1.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## [1.0]
+## [1.0.1]
 
-[1.0]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0
+[1.0.1]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.1
+
+# Added
+
+- Expose a WASM certificate bundle splitter.
+
+## [1.0.0]
+
+[1.0.0]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.0
 
 - First stable release of the TEE attestation verification library.
 - Verifies AMD SEV-SNP attestation reports and collateral, including certificate chains, report signatures, and TCB values.

--- a/demos/web-verify-kernel/README.md
+++ b/demos/web-verify-kernel/README.md
@@ -1,8 +1,8 @@
 # web-verify-kernel — minimal WASM verification demo
 
 A standalone HTML/JS page that exercises the WASM bindings from `ffi.rs`
-(specifically `wasm::verify_attestation_async`) and renders the verified
-SEV-SNP attestation report.
+(`wasm::verify_attestation_async` and `wasm::split_certificate_bundle`) and
+renders the verified SEV-SNP attestation report.
 
 All processing happens client-side; the page makes no network calls other
 than loading its own WASM module.
@@ -30,10 +30,14 @@ After editing Rust sources, rerun step 1 and hard-refresh the browser.
 
 ## Inputs
 
-Four inputs, each accepting either a file upload or pasted text:
+Four verification inputs, each accepting either a file upload or pasted text:
 
 - **Attestation report** — 1184-byte binary (upload) or hex string (textarea).
 - **VCEK**, **ASK**, **ARK** — PEM-encoded certificates.
+
+The optional **ASK/ARK bundle splitter** accepts a PEM bundle containing ASK
+followed by ARK, calls `split_certificate_bundle`, and populates the ASK and
+ARK textareas before verification.
 
 Test fixtures shipped alongside the demo in `./test-data/`:
 

--- a/demos/web-verify-kernel/demo.js
+++ b/demos/web-verify-kernel/demo.js
@@ -1,14 +1,25 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import init, { verify_attestation_async } from "./pkg/tee_attestation_verification_lib.js";
+import init, {
+  split_certificate_bundle,
+  verify_attestation_async,
+} from "./pkg/tee_attestation_verification_lib.js";
 
 const statusEl = document.getElementById("status");
 const outputEl = document.getElementById("output");
+let wasmInitPromise;
 
 function setStatus(msg, kind = "") {
   statusEl.textContent = msg;
   statusEl.className = kind;
+}
+
+function ensureWasmLoaded() {
+  if (!wasmInitPromise) {
+    wasmInitPromise = init();
+  }
+  return wasmInitPromise;
 }
 
 // ----- input helpers --------------------------------------------------------
@@ -41,6 +52,7 @@ function wireFileToText(fileId, textId, transform) {
 wireFileToText("report-file", "report-hex",
   async f => bytesToHex(new Uint8Array(await f.arrayBuffer())));
 wireFileToText("vcek-file", "vcek-text", f => f.text());
+wireFileToText("bundle-file", "bundle-text", f => f.text());
 wireFileToText("ask-file",  "ask-text",  f => f.text());
 wireFileToText("ark-file",  "ark-text",  f => f.text());
 
@@ -54,6 +66,12 @@ function getPem(name, textId) {
   const text = document.getElementById(textId).value;
   if (!text.trim()) throw new Error(`No ${name} PEM provided (upload a file or paste text)`);
   return text;
+}
+
+function errorDetails(err) {
+  const code = err && err.code !== undefined ? ` (code ${err.code})` : "";
+  const msg = err && err.message ? err.message : String(err);
+  return { code, msg };
 }
 
 // ----- formatting -----------------------------------------------------------
@@ -155,12 +173,34 @@ function render(report) {
 
 // ----- main -----------------------------------------------------------------
 
+async function onSplitBundle() {
+  outputEl.textContent = "";
+  setStatus("Loading WASM module...");
+  try {
+    await ensureWasmLoaded();
+    setStatus("Splitting certificate bundle...");
+    const bundlePem = getPem("certificate bundle", "bundle-text");
+    const certificates = split_certificate_bundle(bundlePem);
+    if (certificates.length !== 2) {
+      throw new Error(`Expected 2 certificates (ASK then ARK), got ${certificates.length}`);
+    }
+
+    document.getElementById("ask-text").value = certificates[0];
+    document.getElementById("ark-text").value = certificates[1];
+    setStatus("Split 2 certificates from bundle into ASK and ARK fields.", "ok");
+  } catch (err) {
+    console.error(err);
+    const { msg } = errorDetails(err);
+    setStatus(`Bundle split failed: ${msg}`, "err");
+  }
+}
+
 async function onSubmit(ev) {
   ev.preventDefault();
   outputEl.textContent = "";
   setStatus("Loading WASM module...");
   try {
-    await init();
+    await ensureWasmLoaded();
     setStatus("Reading inputs...");
     const reportBytes = getReportBytes();
     const arkPem  = getPem("ARK",  "ark-text");
@@ -178,10 +218,10 @@ async function onSubmit(ev) {
     // just have .message. Surface whichever we have, and log the raw object
     // to devtools for easier debugging.
     console.error(err);
-    const code = err && err.code !== undefined ? ` (code ${err.code})` : "";
-    const msg = err && err.message ? err.message : String(err);
+    const { code, msg } = errorDetails(err);
     setStatus(`Verification failed${code}: ${msg}`, "err");
   }
 }
 
+document.getElementById("split-bundle").addEventListener("click", onSplitBundle);
 document.getElementById("form").addEventListener("submit", onSubmit);

--- a/demos/web-verify-kernel/index.html
+++ b/demos/web-verify-kernel/index.html
@@ -36,7 +36,9 @@
     Loads four inputs (a binary attestation report plus the ARK, ASK, and VCEK
     certificates in PEM form), calls
     <code>verify_attestation_async</code> from the WASM bindings, and renders
-    the verified report fields.
+    the verified report fields. The optional bundle splitter calls
+    <code>split_certificate_bundle</code> to populate ASK and ARK from a PEM
+    bundle.
   </p>
 
   <form id="form">
@@ -51,6 +53,14 @@
       <legend>VCEK (PEM)</legend>
       <input type="file" id="vcek-file" accept=".pem,.crt,.cert,text/plain" />
       <textarea id="vcek-text" rows="4" placeholder="-----BEGIN CERTIFICATE-----"></textarea>
+    </fieldset>
+
+    <fieldset>
+      <legend>Optional ASK/ARK bundle splitter (PEM)</legend>
+      <p>Paste or upload a PEM bundle containing the ASK certificate followed by the ARK certificate.</p>
+      <input type="file" id="bundle-file" accept=".pem,.crt,.cert,text/plain" />
+      <textarea id="bundle-text" rows="8" placeholder="-----BEGIN CERTIFICATE-----"></textarea>
+      <button type="button" id="split-bundle">Split into ASK and ARK</button>
     </fieldset>
 
     <fieldset>

--- a/demos/web-verify-kernel/tests/README.md
+++ b/demos/web-verify-kernel/tests/README.md
@@ -1,11 +1,11 @@
 # web-verify-kernel end-to-end tests
 
-Playwright test that drives the `demos/web-verify-kernel/` page in a real
-browser, runs the Milan attestation fixture through
-`verify_attestation_async`, and diffs the rendered output against
-`milan_report.expected.txt`. A second test exercises the error-rendering path
-by validating a Milan VCEK→ASK chain against the Turin ARK and checking that
-the rendered status surfaces `ErrorCode::InvalidRootCertificate` (102).
+Playwright tests that drive the `demos/web-verify-kernel/` page in a real
+browser, run the Milan attestation fixture through `verify_attestation_async`,
+and diff the rendered output against `milan_report.expected.txt`. Additional
+tests exercise the ASK/ARK bundle splitter and the error-rendering path by
+validating a Milan VCEK→ASK chain against the Turin ARK and checking that the
+rendered status surfaces `ErrorCode::InvalidRootCertificate` (102).
 
 ## How to run the tests
 

--- a/demos/web-verify-kernel/tests/README.md
+++ b/demos/web-verify-kernel/tests/README.md
@@ -4,7 +4,7 @@ Playwright tests that drive the `demos/web-verify-kernel/` page in a real
 browser, run the Milan attestation fixture through `verify_attestation_async`,
 and diff the rendered output against `milan_report.expected.txt`. Additional
 tests exercise the ASK/ARK bundle splitter and the error-rendering path by
-validating a Milan VCEK→ASK chain against the Turin ARK and checking that the
+validating a Milan VCEK->ASK chain against the Turin ARK and checking that the
 rendered status surfaces `ErrorCode::InvalidRootCertificate` (102).
 
 ## How to run the tests

--- a/demos/web-verify-kernel/tests/e2e.spec.js
+++ b/demos/web-verify-kernel/tests/e2e.spec.js
@@ -81,6 +81,40 @@ test("Milan fixture renders the expected report", async ({ page, baseURL }) => {
   expect(rendered).toBe(expected);
 });
 
+test("ASK/ARK bundle can be split into certificate inputs before verification", async ({ page, baseURL }) => {
+  const get = async path => {
+    const r = await fetch(baseURL + path);
+    if (!r.ok) throw new Error(`fetch ${path} -> ${r.status}`);
+    return r;
+  };
+  const reportBytes = new Uint8Array(await (await get(FIXTURES.milanReport)).arrayBuffer());
+  const vcekPem = await (await get(FIXTURES.milanVcek)).text();
+  const askPem  = await (await get(FIXTURES.milanAsk)).text();
+  const arkPem  = await (await get(FIXTURES.milanArk)).text();
+
+  await page.goto("/");
+
+  const reportHex = Array.from(reportBytes, b => b.toString(16).padStart(2, "0")).join("");
+  await page.locator("#report-hex").fill(reportHex);
+  await page.locator("#vcek-text").fill(vcekPem);
+  await page.locator("#bundle-text").fill(`${askPem}\n${arkPem}`);
+
+  await page.locator("#split-bundle").click();
+
+  await expect(page.locator("#status")).toHaveClass("ok", { timeout: 30_000 });
+  await expect(page.locator("#status")).toHaveText("Split 2 certificates from bundle into ASK and ARK fields.");
+  const splitAsk = await page.locator("#ask-text").inputValue();
+  const splitArk = await page.locator("#ark-text").inputValue();
+  expect(splitAsk).toContain("-----BEGIN CERTIFICATE-----");
+  expect(splitArk).toContain("-----BEGIN CERTIFICATE-----");
+  expect(splitAsk).not.toBe(splitArk);
+
+  await page.locator('button[type="submit"]').click();
+  await expect(page.locator("#status")).toHaveClass("ok", { timeout: 30_000 });
+  await expect(page.locator("#status")).toHaveText("Signature chain verified against supplied ARK.");
+  await expect(page.locator("#output")).not.toHaveText("");
+});
+
 test("mismatched ARK (Turin against Milan chain) surfaces a verification error and suppresses output", async ({ page, baseURL }) => {
   // Use the real Milan fixtures for everything except the ARK, which is
   // replaced with the Turin ARK. This is a valid certificate but does not

--- a/src/snp/ffi.rs
+++ b/src/snp/ffi.rs
@@ -176,6 +176,7 @@ pub mod wasm {
     //! See `demos/web-verify-kernel/README.md` in the repository for a runnable
     //! browser demo that uses these bindings.
 
+    use js_sys::Array;
     use wasm_bindgen::prelude::*;
     use zerocopy::FromBytes;
 
@@ -232,6 +233,29 @@ pub mod wasm {
         Ok(SnpAttestationReport {
             bytes: report_bytes,
         })
+    }
+
+    /// Split a PEM certificate bundle into individual PEM certificates.
+    ///
+    /// Parses the bundle with the active crypto backend and returns certificates
+    /// in the same order they appeared in the input.
+    #[wasm_bindgen]
+    pub fn split_certificate_bundle(pem_bundle: &str) -> Result<Array, String> {
+        if pem_bundle.trim().is_empty() {
+            return Err("Certificate bundle PEM is empty".into());
+        }
+
+        let certificates = Crypto::from_pem_chain(pem_bundle.as_bytes())
+            .map_err(|e| format!("Failed to parse certificate bundle PEM: {e}"))?;
+
+        let split = Array::new();
+        for certificate in certificates {
+            let pem = Crypto::to_pem(&certificate)
+                .map_err(|e| format!("Failed to encode certificate PEM: {e}"))?;
+            split.push(&JsValue::from_str(&pem));
+        }
+
+        Ok(split)
     }
 
     fn parse_report(bytes: &[u8]) -> Result<&AttestationReport, VerifyError> {
@@ -500,6 +524,62 @@ pub mod wasm {
         #[wasm_bindgen(getter)]
         pub fn signature_s(&self) -> Vec<u8> {
             self.report().signature.s.to_vec()
+        }
+    }
+
+    #[cfg(test)]
+    mod split_tests {
+        use super::*;
+        use wasm_bindgen_test::wasm_bindgen_test;
+
+        const MILAN_ARK: &str = include_str!("../pinned_arks/milan_ark.pem");
+        const MILAN_ASK: &str = include_str!("../../tests/test_data/milan_ask.pem");
+
+        #[wasm_bindgen_test]
+        fn split_certificate_bundle_returns_pem_certificates_in_order() {
+            let bundle = format!("{MILAN_ASK}\n{MILAN_ARK}");
+
+            let split = split_certificate_bundle(&bundle).expect("bundle should split");
+
+            assert_eq!(split.length(), 2);
+            assert_certificate_matches_pem(&split, 0, MILAN_ASK);
+            assert_certificate_matches_pem(&split, 1, MILAN_ARK);
+        }
+
+        #[wasm_bindgen_test]
+        fn split_certificate_bundle_rejects_empty_bundle() {
+            let err = match split_certificate_bundle("") {
+                Ok(_) => panic!("empty bundle should fail"),
+                Err(err) => err,
+            };
+
+            assert!(err.contains("empty"));
+        }
+
+        #[wasm_bindgen_test]
+        fn split_certificate_bundle_rejects_invalid_pem() {
+            let err = match split_certificate_bundle("not a pem") {
+                Ok(_) => panic!("invalid bundle should fail"),
+                Err(err) => err,
+            };
+
+            assert!(err.contains("certificate bundle PEM"));
+        }
+
+        fn assert_certificate_matches_pem(split: &Array, index: u32, expected_pem: &str) {
+            let actual_pem = split
+                .get(index)
+                .as_string()
+                .expect("split certificate should be a PEM string");
+            let actual = Crypto::from_pem(actual_pem.as_bytes())
+                .expect("split certificate PEM should parse");
+            let expected =
+                Crypto::from_pem(expected_pem.as_bytes()).expect("fixture PEM should parse");
+
+            assert_eq!(
+                Crypto::to_der(&actual).expect("split certificate should encode as DER"),
+                Crypto::to_der(&expected).expect("fixture certificate should encode as DER")
+            );
         }
     }
 


### PR DESCRIPTION
This exposes certificate splitting from the WASM to make integration with ACI easier.