### PR TITLE
Use wasm64

### DIFF
--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [package.metadata.docs.rs]
 features = ["crypto_openssl", "crypto_webcrypto", "kds"]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown", "wasm64-unknown-unknown"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -33,7 +33,7 @@ required-features = ["kds"]
 wasm-bindgen-test = "0.3"
 env_logger = "0.11"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
@@ -44,12 +44,12 @@ zerocopy = {version = "0.8.31", features = ["derive"]}
 log = { version = "0.4" }
 
 # Native deps
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true}
 curl = { version = "0.4", optional = true }
 
 # WASM deps
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/attestation/src/snp/ffi.rs
+++ b/attestation/src/snp/ffi.rs
@@ -6,7 +6,7 @@
 //! [`crate::snp::ffi::ErrorCode`] and [`crate::snp::ffi::VerifyError`] classify
 //! verification failures in a form suitable for non-Rust callers.
 //! Target-specific bindings live under submodules; the `wasm` submodule is
-//! compiled only for `wasm32` and exposes the caller-provided-certificate
+//! compiled only for WASM targets and exposes the caller-provided-certificate
 //! WebAssembly API.
 //!
 //! A sync `verify_attestation` for C FFI consumers will be added alongside the
@@ -14,7 +14,7 @@
 
 use crate::snp::verify::VerificationError;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 use wasm_bindgen::prelude::*;
 
 // ---------------------------------------------------------------------------
@@ -27,7 +27,7 @@ use wasm_bindgen::prelude::*;
 /// `TAVErrorCode` values when that surface is added:
 /// - 1: input parsing / validation
 /// - 101–105: attestation verification (mapped from [`VerificationError`])
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCode {
@@ -46,23 +46,23 @@ pub enum ErrorCode {
 }
 
 /// An error returned by the verify functions.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 #[derive(Debug)]
 pub struct VerifyError {
     code: ErrorCode,
     message: String,
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(target_family = "wasm", wasm_bindgen)]
 impl VerifyError {
     /// The error category.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(getter))]
     pub fn code(&self) -> ErrorCode {
         self.code
     }
 
     /// The human-readable error message.
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen(getter))]
     pub fn message(&self) -> String {
         self.message.clone()
     }
@@ -71,7 +71,7 @@ impl VerifyError {
 impl VerifyError {
     // Only used by the wasm module today; the C FFI layer will use it too
     // when it lands. Silence dead_code on builds without any consumer.
-    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    #[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
     pub(crate) fn invalid_argument(message: String) -> Self {
         Self {
             code: ErrorCode::InvalidArgument,
@@ -165,7 +165,7 @@ mod tests {
 // WASM bindings
 // ---------------------------------------------------------------------------
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub mod wasm {
     //! `wasm_bindgen` bindings exposing verified SNP attestation reports to JS.
     //!

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -37,11 +37,11 @@ rsa = { version = "0.9", optional = true }
 sha2 = { version = "0.10", optional = true }
 x509-cert = { version = "0.2", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 openssl = { version = "0.10", optional = true }
 openssl-sys = { version = "0.9", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", optional = true }
 js-sys = "0.3"
 wasm-bindgen = "0.2"
@@ -50,5 +50,5 @@ wasm-bindgen-futures = "0.4"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crypto/build.rs
+++ b/crypto/build.rs
@@ -6,12 +6,14 @@ fn main() {
     );
 
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap_or_default();
+    let is_wasm = target_family == "wasm";
     let has_openssl = std::env::var_os("CARGO_FEATURE_CRYPTO_OPENSSL").is_some();
     let has_pure_rust = std::env::var_os("CARGO_FEATURE_CRYPTO_PURE_RUST").is_some();
     let has_webcrypto = std::env::var_os("CARGO_FEATURE_CRYPTO_WEBCRYPTO").is_some();
 
     // Allow both webcrypto and openssl to be enabled, and to choose the one which is supported on the target platform.
-    let crypto_backend = if target_arch != "wasm32" {
+    let crypto_backend = if !is_wasm {
         if has_openssl {
             "crypto_openssl"
         } else if has_pure_rust {
@@ -21,14 +23,14 @@ fn main() {
               "On native targets, at least one of `crypto_openssl` or `crypto_pure_rust` must be enabled."
             );
         }
-    } else if target_arch == "wasm32" {
+    } else if is_wasm {
         if has_webcrypto {
             "crypto_webcrypto"
         } else if has_pure_rust {
             "crypto_pure_rust"
         } else {
             panic!(
-              "On wasm32 targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled."
+              "On WASM targets, at least one of `crypto_webcrypto` or `crypto_pure_rust` must be enabled."
             );
         }
     } else {

--- a/demos/web-verify-kernel/tests/package.json
+++ b/demos/web-verify-kernel/tests/package.json
@@ -8,6 +8,6 @@
     "update-golden": "UPDATE_GOLDEN=1 playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "1.50.1"
+    "@playwright/test": "1.60.0"
   }
 }

--- a/demos/web-verify-kernel/tests/playwright.config.js
+++ b/demos/web-verify-kernel/tests/playwright.config.js
@@ -8,6 +8,7 @@ import { dirname, resolve } from "node:path";
 const here = dirname(fileURLToPath(import.meta.url));
 // The demo directory is one level up from demos/web-verify-kernel/tests/.
 const demoRoot = resolve(here, "..");
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE;
 
 export default defineConfig({
   testDir: ".",
@@ -26,5 +27,13 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:8123",
   },
-  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+  projects: [{
+    name: "chromium",
+    use: {
+      browserName: "chromium",
+      launchOptions: chromiumExecutablePath
+        ? { executablePath: chromiumExecutablePath }
+        : undefined,
+    },
+  }],
 });


### PR DESCRIPTION
This is required for evercbor which currently requires 64 bit pointers.
Concurrently we will try to get support for 32 bit pointers in evercbor and then can migrate back to wasm32, as the support for wasm64 is not 100% yet.