### PR TITLE
Harden actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 5

--- a/.github/workflows/ci-attestation.yml
+++ b/.github/workflows/ci-attestation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install rust
         run: |
           rustup update stable && rustup default stable
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install rust
         run: |
           rustup update stable && rustup default stable

--- a/.github/workflows/ci-crypto.yml
+++ b/.github/workflows/ci-crypto.yml
@@ -26,7 +26,7 @@ jobs:
             features: crypto_pure_rust
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install rust
         run: |
           rustup update stable && rustup default stable
@@ -50,7 +50,7 @@ jobs:
             features: crypto_pure_rust
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install rust
         run: |
           rustup update stable && rustup default stable

--- a/.github/workflows/ci-demo.yml
+++ b/.github/workflows/ci-demo.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install rust
         run: |
@@ -35,7 +35,7 @@ jobs:
         run: wasm-pack build --target web --out-dir ../demos/web-verify-kernel/pkg --no-default-features --features "crypto_webcrypto"
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: web-verify-kernel-playwright-report
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install rust
         run: |
           rustup update stable && rustup default stable
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install rust
         run: |
           rustup update stable && rustup default stable
@@ -44,65 +44,3 @@ jobs:
 
       - name: WASM build docs
         run: cargo doc -p tee-attestation-verification-lib --target wasm32-unknown-unknown
-
-  coverage:
-    name: Workspace test coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install rust
-        run: |
-          rustup update stable && rustup default stable
-          rustup component add llvm-tools-preview
-
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Clean coverage artifacts
-        run: cargo llvm-cov clean --workspace
-
-      - name: Collect coverage data (OpenSSL backend)
-        run: |
-          cargo llvm-cov --workspace --no-default-features --features "crypto_openssl" \
-            --no-report
-
-      - name: Collect coverage and combine LCOV report (pure-Rust backend)
-        run: |
-          # --no-clean preserves the OpenSSL profile data so the report
-          # summarizes coverage across both workspace test suites and native backends.
-          cargo llvm-cov --workspace --no-default-features --features "crypto_pure_rust" \
-            --no-clean --lcov --output-path lcov-combined.info \
-            --ignore-filename-regex '(^|/)(test_data|tests|demos)(/|$)|(^|/)src/bin/'
-
-      - name: Generate combined coverage summary
-        run: |
-          cargo llvm-cov report --summary-only \
-            --ignore-filename-regex '(^|/)(test_data|tests|demos)(/|$)|(^|/)src/bin/' \
-            | tee coverage-summary.txt
-          line_coverage=$(awk '/^TOTAL/ { print $10 }' coverage-summary.txt)
-          region_coverage=$(awk '/^TOTAL/ { print $4 }' coverage-summary.txt)
-          function_coverage=$(awk '/^TOTAL/ { print $7 }' coverage-summary.txt)
-          {
-            echo '## Workspace test coverage (combined native backends)';
-            echo '';
-            echo "**Overall:** ${line_coverage} lines, ${region_coverage} regions, ${function_coverage} functions";
-            echo '';
-            echo '<details open>';
-            echo '<summary>Per-file coverage</summary>';
-            echo '';
-            echo '```';
-            cat coverage-summary.txt;
-            echo '```';
-            echo '';
-            echo '</details>';
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload coverage reports
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-reports
-          path: |
-            lcov-combined.info
-            coverage-summary.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       commit_sha: ${{ steps.prepare.outputs.commit_sha }}
       crate_name: ${{ steps.prepare.outputs.crate_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.prepare_release.outputs.commit_sha }}
 
@@ -116,7 +116,7 @@ jobs:
         run: wasm-pack test --node --no-default-features --features "crypto_webcrypto"
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
@@ -142,7 +142,7 @@ jobs:
       CRATE_NAME: ${{ needs.prepare_release.outputs.crate_name }}
       VERSION: ${{ needs.prepare_release.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.prepare_release.outputs.commit_sha }}
 
@@ -176,7 +176,7 @@ jobs:
           )
 
       - name: Upload WASM release artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-artifacts
           path: attestation/dist/*
@@ -191,12 +191,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.prepare_release.outputs.commit_sha }}
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts
           path: dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,38 +12,3 @@ instructions provided by the bot. You will only need to do this once across all 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-## Test coverage
-
-Test coverage is collected in CI by the workspace `coverage` job using
-[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov). The job runs the
-crypto and attestation native test suites with the OpenSSL and pure-Rust
-backends, then uploads a combined LCOV report (`lcov-combined.info`) and a
-human-readable summary as the
-`coverage-reports` workflow artifact. The combined summary is also written to
-the job summary page.
-
-To reproduce locally:
-
-```bash
-rustup component add llvm-tools-preview
-cargo install cargo-llvm-cov --locked
-
-cargo llvm-cov clean --workspace
-
-# Collect OpenSSL coverage data without reporting yet.
-cargo llvm-cov --workspace --no-default-features --features "crypto_openssl" \
-    --no-report
-
-# Preserve the OpenSSL profile data, run pure_rust tests, and emit combined LCOV.
-cargo llvm-cov --workspace --no-default-features --features "crypto_pure_rust" \
-    --no-clean --lcov --output-path lcov-combined.info \
-    --ignore-filename-regex '(^|/)(test_data|tests|demos)(/|$)|(^|/)src/bin/'
-
-# Summary in the terminal
-cargo llvm-cov report --summary-only \
-    --ignore-filename-regex '(^|/)(test_data|tests|demos)(/|$)|(^|/)src/bin/'
-```
-
-The `--ignore-filename-regex` flag excludes test fixtures, demos, and the CLI
-binary from the measured surface so the percentages reflect library code only.


### PR DESCRIPTION
Pin the version of all actions.
Add dependabot to check for outdated versions.
Remove the code coverage as it relied on a non-github action, and I think that is too much of a risk. We can still run it manually.