### PR TITLE
Bump evercbor and remove dependency on wasm64

### DIFF
--- a/.github/workflows/ci-attestation.yml
+++ b/.github/workflows/ci-attestation.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Setup WASM tooling
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
           cargo install wasm-pack --version 0.13.1 --locked
 
       - name: Build WASM

--- a/.github/workflows/ci-caci.yml
+++ b/.github/workflows/ci-caci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Test with ${{ matrix.backend.name }} backend
         run: cargo test --manifest-path caci/Cargo.toml --no-default-features --features "${{ matrix.backend.features }}" -- --nocapture
 
-  wasm64:
-    name: WASM64 WebCrypto build and test
+  wasm:
+    name: WASM WebCrypto build and test
     runs-on: ubuntu-latest
 
     steps:
@@ -47,45 +47,17 @@ jobs:
 
       - name: Install rust
         run: |
-          rustup update nightly
-          rustup +nightly component add rust-src
+          rustup update stable && rustup default stable
 
       - name: Setup WASM tooling
         run: |
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-pack --version 0.13.1 --locked
 
-      # ACI depends on EverParse CBOR code that requires 64-bit usize.
-      # wasm64-unknown-unknown does not have a prebuilt rust-std
-      # component, so use nightly Cargo build-std with rust-src instead of
-      # rustup target add. wasm-bindgen only generates JS bindings from the
-      # already-built wasm artifact.
-      - name: Build WASM64 with WebCrypto backend
-        run: |
-          cargo +nightly build -Z build-std=std,panic_abort \
-            --manifest-path caci/Cargo.toml \
-            --target wasm64-unknown-unknown \
-            --no-default-features \
-            --features "crypto_webcrypto" \
-            --release
+      - name: Build WASM with WebCrypto backend
+        working-directory: caci
+        run: wasm-pack build --target web --no-default-features --features "crypto_webcrypto"
 
-      - name: Generate WASM bindings
-        run: wasm-bindgen --target web --out-dir caci/pkg target/wasm64-unknown-unknown/release/tee_attestation_verification_caci.wasm
-
-      - name: Compile WASM64 tests with WebCrypto backend
-        run: |
-          cargo +nightly test -Z build-std=std,panic_abort \
-            --manifest-path caci/Cargo.toml \
-            --target wasm64-unknown-unknown \
-            --no-default-features \
-            --features "crypto_webcrypto" \
-            --no-run
-
-      - name: Setup Node 26
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: "26"
-
-      - name: Test WASM64 with WebCrypto backend
-        run: |
-          test_wasm=$(find target/wasm64-unknown-unknown/debug/deps -maxdepth 1 -name 'tee_attestation_verification_caci-*.wasm' -printf '%T@ %p\n' | sort -nr | head -n 1 | cut -d' ' -f2-)
-          wasm-bindgen-test-runner --nocapture "$test_wasm"
+      - name: Test WASM with WebCrypto backend
+        working-directory: caci
+        run: wasm-pack test --node --no-default-features --features "crypto_webcrypto"

--- a/.github/workflows/ci-cose.yml
+++ b/.github/workflows/ci-cose.yml
@@ -14,33 +14,27 @@ permissions:
 
 jobs:
   wasm:
-    name: WASM64 pure-Rust build and test
+    name: WASM pure-Rust build and test
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install rust
         run: |
-          rustup update nightly
-          rustup +nightly component add rust-src
+          rustup update stable && rustup default stable
 
       - name: Setup WASM tooling
         run: |
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-pack --version 0.13.1 --locked
 
-      # COSE depends on EverParse CBOR code that requires 64-bit usize.
-      # wasm64-unknown-unknown does not have a prebuilt rust-std
-      # component, so use nightly Cargo build-std with rust-src instead of
-      # rustup target add. wasm-bindgen only generates JS bindings from the
-      # already-built wasm artifact.
-      - name: Build WASM64 with pure-Rust backend
-        run: cargo +nightly build -Z build-std=std,panic_abort --manifest-path cose/Cargo.toml --target wasm64-unknown-unknown --no-default-features --features "crypto_pure_rust" --release
+      - name: Build WASM with pure-Rust backend
+        working-directory: cose
+        run: wasm-pack build --target web --no-default-features --features "crypto_pure_rust"
 
-      - name: Generate WASM bindings
-        run: wasm-bindgen --target web --out-dir cose/pkg target/wasm64-unknown-unknown/release/tee_attestation_verification_cose.wasm
-
-      - name: Compile WASM64 tests with pure-Rust backend
-        run: cargo +nightly test -Z build-std=std,panic_abort --manifest-path cose/Cargo.toml --target wasm64-unknown-unknown --no-default-features --features "crypto_pure_rust" --no-run
+      - name: Test WASM with pure-Rust backend
+        working-directory: cose
+        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust"
 
   native:
     name: Native build and test

--- a/.github/workflows/ci-crypto.yml
+++ b/.github/workflows/ci-crypto.yml
@@ -58,7 +58,6 @@ jobs:
       - name: Setup WASM tooling
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
           cargo install wasm-pack --version 0.13.1 --locked
 
       - name: Check ${{ matrix.backend.name }} backend

--- a/.github/workflows/ci-demo.yml
+++ b/.github/workflows/ci-demo.yml
@@ -182,29 +182,15 @@ jobs:
       - name: Install rust
         run: |
           rustup update stable && rustup default stable
-          rustup toolchain install nightly
-          rustup +nightly component add rust-src
 
       - name: Setup WASM tooling
         run: |
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-pack --version 0.13.1 --locked
 
-      # ACI depends on EverParse CBOR code that requires 64-bit usize.
-      # wasm64-unknown-unknown does not have a prebuilt rust-std
-      # component, so use nightly Cargo build-std with rust-src instead of
-      # rustup target add. wasm-bindgen only generates JS bindings from the
-      # already-built wasm artifact.
       - name: Build CACI WASM for the demo
-        run: |
-          cargo +nightly build -Z build-std=std,panic_abort \
-            --manifest-path caci/Cargo.toml \
-            --target wasm64-unknown-unknown \
-            --no-default-features \
-            --features "crypto_webcrypto" \
-            --release
-          wasm-bindgen --target web \
-            --out-dir demos/caci-attestation-verify/caci_pkg \
-            target/wasm64-unknown-unknown/release/tee_attestation_verification_caci.wasm
+        working-directory: caci
+        run: wasm-pack build --target web --out-dir ../demos/caci-attestation-verify/caci_pkg --no-default-features --features "crypto_webcrypto"
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,11 @@ jobs:
         run: |
           rustup update stable
           rustup default stable
-          rustup update nightly
-          rustup +nightly component add rust-src
 
       - name: Setup WASM tooling
         shell: bash
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
           cargo install wasm-pack --version 0.13.1 --locked
 
       - name: Build with openssl
@@ -136,22 +133,9 @@ jobs:
         working-directory: demos/web-verify-kernel/tests
         run: npm test
 
-      # ACI depends on EverParse CBOR code that requires 64-bit usize.
-      # wasm64-unknown-unknown does not have a prebuilt rust-std
-      # component, so use nightly Cargo build-std with rust-src instead of
-      # rustup target add. wasm-bindgen only generates JS bindings from the
-      # already-built wasm artifact.
-      - name: Build WASM64 for the caci-attestation-verify demo
-        run: |
-          cargo +nightly build -Z build-std=std,panic_abort \
-            --manifest-path caci/Cargo.toml \
-            --target wasm64-unknown-unknown \
-            --no-default-features \
-            --features "crypto_webcrypto" \
-            --release
-          wasm-bindgen --target web \
-            --out-dir demos/caci-attestation-verify/caci_pkg \
-            target/wasm64-unknown-unknown/release/tee_attestation_verification_caci.wasm
+      - name: Build WASM for the caci-attestation-verify demo
+        working-directory: caci
+        run: wasm-pack build --target web --out-dir ../demos/caci-attestation-verify/caci_pkg --no-default-features --features "crypto_webcrypto"
 
       - name: Install caci-attestation-verify demo test deps
         working-directory: demos/caci-attestation-verify/tests
@@ -179,14 +163,11 @@ jobs:
         run: |
           rustup update stable
           rustup default stable
-          rustup update nightly
-          rustup +nightly component add rust-src
 
       - name: Setup WASM tooling
         shell: bash
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo install wasm-bindgen-cli --version 0.2.122 --locked
           cargo install wasm-pack --version 0.13.1 --locked
 
       - name: Build tav-attestation WASM bundle with WebCrypto crypto
@@ -214,14 +195,12 @@ jobs:
 
           mkdir -p ../dist/tav-caci ../release-artifacts
 
-          cargo +nightly build -Z build-std=std,panic_abort \
-            --target wasm64-unknown-unknown \
-            --no-default-features \
-            --features "crypto_webcrypto" \
-            --release
-          wasm-bindgen --target web \
+          wasm-pack build \
+            --target web \
+            --release \
             --out-dir ../dist/tav-caci \
-            ../target/wasm64-unknown-unknown/release/tee_attestation_verification_caci.wasm
+            --no-default-features \
+            --features "crypto_webcrypto"
 
           tar -C ../dist -czf "../release-artifacts/tav-caci-${VERSION}.tar.gz" tav-caci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,15 +104,15 @@ jobs:
 
       - name: Build WASM with WebCrypto crypto
         working-directory: attestation
-        run: wasm-pack build --target web --no-default-features --features "crypto_webcrypto"
+        run: wasm-pack build --target web --release --no-default-features --features "crypto_webcrypto"
 
       - name: Test WASM offline
         working-directory: attestation
-        run: wasm-pack test --node --no-default-features --features "crypto_pure_rust"
+        run: wasm-pack test --node --release --no-default-features --features "crypto_pure_rust"
 
       - name: Test WASM offline with WebCrypto backend
         working-directory: attestation
-        run: wasm-pack test --node --no-default-features --features "crypto_webcrypto"
+        run: wasm-pack test --node --release --no-default-features --features "crypto_webcrypto"
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build WASM for the web-verify-kernel demo
         working-directory: attestation
-        run: wasm-pack build --target web --out-dir ../demos/web-verify-kernel/pkg --no-default-features --features "crypto_webcrypto"
+        run: wasm-pack build --target web --out-dir ../demos/web-verify-kernel/pkg --release --no-default-features --features "crypto_webcrypto"
 
       - name: Install web-verify-kernel demo test deps
         working-directory: demos/web-verify-kernel/tests
@@ -135,7 +135,7 @@ jobs:
 
       - name: Build WASM for the caci-attestation-verify demo
         working-directory: caci
-        run: wasm-pack build --target web --out-dir ../demos/caci-attestation-verify/caci_pkg --no-default-features --features "crypto_webcrypto"
+        run: wasm-pack build --target web --out-dir ../demos/caci-attestation-verify/caci_pkg --release --no-default-features --features "crypto_webcrypto"
 
       - name: Install caci-attestation-verify demo test deps
         working-directory: demos/caci-attestation-verify/tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Expose the crypto backend as its own crate. (#51)
+- Add `wasm32-unknown-unknown` compatibility for COSE/CACI by bumping EverParse CBOR (`cborrs`/`cborrs-nondet`) to include project-everest/everparse#296, allowing WASM builds to use stable `wasm-pack`. (#71)
 
 ## [1.0.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,18 +120,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 [[package]]
 name = "cborrs"
 version = "0.1.0"
-source = "git+https://github.com/project-everest/everparse.git?rev=f4cd5ffa183edd5cc824d66588012bcf8d0bdccd#f4cd5ffa183edd5cc824d66588012bcf8d0bdccd"
-dependencies = [
- "static_assertions",
-]
+source = "git+https://github.com/project-everest/everparse.git?rev=b3544a15b51e6346f449baa04eb466a185167e4d#b3544a15b51e6346f449baa04eb466a185167e4d"
 
 [[package]]
 name = "cborrs-nondet"
 version = "0.1.0"
-source = "git+https://github.com/project-everest/everparse.git?rev=f4cd5ffa183edd5cc824d66588012bcf8d0bdccd#f4cd5ffa183edd5cc824d66588012bcf8d0bdccd"
-dependencies = [
- "static_assertions",
-]
+source = "git+https://github.com/project-everest/everparse.git?rev=b3544a15b51e6346f449baa04eb466a185167e4d#b3544a15b51e6346f449baa04eb466a185167e4d"
 
 [[package]]
 name = "cc"
@@ -1023,12 +1017,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,12 +120,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 [[package]]
 name = "cborrs"
 version = "0.1.0"
-source = "git+https://github.com/project-everest/everparse.git?rev=b3544a15b51e6346f449baa04eb466a185167e4d#b3544a15b51e6346f449baa04eb466a185167e4d"
+source = "git+https://github.com/project-everest/everparse.git?tag=v2026.07.02#950bc93838ac2faae51126d8acd0637cf8c8a569"
 
 [[package]]
 name = "cborrs-nondet"
 version = "0.1.0"
-source = "git+https://github.com/project-everest/everparse.git?rev=b3544a15b51e6346f449baa04eb466a185167e4d#b3544a15b51e6346f449baa04eb466a185167e4d"
+source = "git+https://github.com/project-everest/everparse.git?tag=v2026.07.02#950bc93838ac2faae51126d8acd0637cf8c8a569"
 
 [[package]]
 name = "cc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,12 +120,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 [[package]]
 name = "cborrs"
 version = "0.1.0"
-source = "git+https://github.com/project-everest/everparse.git?tag=v2026.07.02#950bc93838ac2faae51126d8acd0637cf8c8a569"
+source = "git+https://github.com/project-everest/everparse.git?rev=950bc93838ac2faae51126d8acd0637cf8c8a569#950bc93838ac2faae51126d8acd0637cf8c8a569"
 
 [[package]]
 name = "cborrs-nondet"
 version = "0.1.0"
-source = "git+https://github.com/project-everest/everparse.git?tag=v2026.07.02#950bc93838ac2faae51126d8acd0637cf8c8a569"
+source = "git+https://github.com/project-everest/everparse.git?rev=950bc93838ac2faae51126d8acd0637cf8c8a569#950bc93838ac2faae51126d8acd0637cf8c8a569"
 
 [[package]]
 name = "cc"

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [package.metadata.docs.rs]
 features = ["crypto_openssl", "crypto_webcrypto", "kds"]
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown", "wasm64-unknown-unknown"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 
 [package.metadata.docs.rs]
 features = ["crypto_openssl", "crypto_webcrypto"]
-targets = ["x86_64-unknown-linux-gnu", "wasm64-unknown-unknown"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/caci/README.md
+++ b/caci/README.md
@@ -46,7 +46,7 @@ let verified_report_data = tav::verify_caci_attestation(
 
 Release tags use the `tav-<crate-version>` format.
 
-Releases include `tav-caci-<version>.tar.gz`, a WASM64 and JS wrapper tarball
+Releases include `tav-caci-<version>.tar.gz`, a WASM and JS wrapper tarball
 for direct consumption. Download and extract the matching GitHub release asset
 for your chosen tag into a directory served by your application:
 

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -19,8 +19,8 @@ crypto_webcrypto = ["crypto/crypto_webcrypto"]
 
 [dependencies]
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.2", path = "../crypto", default-features = false }
-cborrs = { git = "https://github.com/project-everest/everparse.git", rev = "b3544a15b51e6346f449baa04eb466a185167e4d" } # project-everest/everparse#296
-cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", rev = "b3544a15b51e6346f449baa04eb466a185167e4d" } # project-everest/everparse#296
+cborrs = { git = "https://github.com/project-everest/everparse.git", tag = "v2026.07.02" }
+cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", tag = "v2026.07.02" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3"

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -19,8 +19,8 @@ crypto_webcrypto = ["crypto/crypto_webcrypto"]
 
 [dependencies]
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.2", path = "../crypto", default-features = false }
-cborrs = { git = "https://github.com/project-everest/everparse.git", rev = "f4cd5ffa183edd5cc824d66588012bcf8d0bdccd" } # v2026.02.25
-cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", rev = "f4cd5ffa183edd5cc824d66588012bcf8d0bdccd" } # v2026.02.25
+cborrs = { git = "https://github.com/project-everest/everparse.git", rev = "b3544a15b51e6346f449baa04eb466a185167e4d" } # project-everest/everparse#296
+cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", rev = "b3544a15b51e6346f449baa04eb466a185167e4d" } # project-everest/everparse#296
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3"

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -19,8 +19,9 @@ crypto_webcrypto = ["crypto/crypto_webcrypto"]
 
 [dependencies]
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.2", path = "../crypto", default-features = false }
-cborrs = { git = "https://github.com/project-everest/everparse.git", tag = "v2026.07.02" }
-cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", tag = "v2026.07.02" }
+# project-everest/everparse tag v2026.07.02 resolves to this pinned commit.
+cborrs = { git = "https://github.com/project-everest/everparse.git", rev = "950bc93838ac2faae51126d8acd0637cf8c8a569" }
+cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", rev = "950bc93838ac2faae51126d8acd0637cf8c8a569" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3"

--- a/cose/README.md
+++ b/cose/README.md
@@ -89,23 +89,18 @@ tav::cose_verify1(
 
 For WebCrypto or other async backends, use `asynchronous::cose_verify1`.
 
-## WASM64
+## WASM
 
 The COSE crate depends on EverParse CBOR Rust code (`cborrs`). That generated
-code currently requires a 64-bit `usize`, so COSE WASM builds use
-`wasm64-unknown-unknown` with Cargo nightly `build-std`. The target does not
-have a prebuilt `rust-std` component, so install `rust-src` and do not run
-`rustup target add wasm64-unknown-unknown`:
+code supports `wasm32-unknown-unknown` builds:
 
 ```bash
-rustup toolchain install nightly
-rustup +nightly component add rust-src
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack --version 0.13.1 --locked
 
-cargo +nightly build -Z build-std=std,panic_abort \
-  --manifest-path cose/Cargo.toml \
-  --target wasm64-unknown-unknown \
-  --no-default-features \
-  --features crypto_pure_rust
+cd cose
+wasm-pack build --target web --no-default-features --features crypto_pure_rust
+wasm-pack test --node --no-default-features --features crypto_pure_rust
 ```
 
 ## Trademarks

--- a/demos/caci-attestation-verify/README.md
+++ b/demos/caci-attestation-verify/README.md
@@ -28,28 +28,21 @@ Open <http://localhost:8000/> in a browser.
 
 ### Option B: build from source
 
-From the repository root, build the CACI WASM package as wasm64, emitting
+From the repository root, build the CACI WASM package, emitting
 `caci_pkg/` directly inside this demo directory:
 
-ACI depends on EverParse CBOR code that requires a 64-bit `usize`. Build it as
-`wasm64-unknown-unknown` with nightly `build-std`; the target does not have a
-prebuilt `rust-std` component, so install `rust-src` and do not run
-`rustup target add wasm64-unknown-unknown`.
-
 ```sh
-rustup toolchain install nightly
-rustup +nightly component add rust-src
-cargo install wasm-bindgen-cli --version 0.2.122 --locked
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack --version 0.13.1 --locked
 
-cargo +nightly build -Z build-std=std,panic_abort \
-  --manifest-path caci/Cargo.toml \
-  --target wasm64-unknown-unknown \
-  --no-default-features \
-  --features "crypto_webcrypto" \
-  --release
-wasm-bindgen --target web \
-  --out-dir demos/caci-attestation-verify/caci_pkg \
-  target/wasm64-unknown-unknown/release/tee_attestation_verification_caci.wasm
+(
+  cd caci
+  wasm-pack build \
+    --target web \
+    --out-dir ../demos/caci-attestation-verify/caci_pkg \
+    --no-default-features \
+    --features "crypto_webcrypto"
+)
 ```
 
 Serve this directory over HTTP:

--- a/demos/caci-attestation-verify/tests/README.md
+++ b/demos/caci-attestation-verify/tests/README.md
@@ -7,25 +7,18 @@ run the Confidential CACI fixture through the staged CACI WASM bindings.
 
 From the repository root, build the CACI WASM package:
 
-ACI depends on EverParse CBOR code that requires a 64-bit `usize`. Build it as
-`wasm64-unknown-unknown` with nightly `build-std`; the target does not have a
-prebuilt `rust-std` component, so install `rust-src` and do not run 
-`rustup target add wasm64-unknown-unknown`.
-
 ```sh
-rustup toolchain install nightly
-rustup +nightly component add rust-src
-cargo install wasm-bindgen-cli --version 0.2.122 --locked
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack --version 0.13.1 --locked
 
-cargo +nightly build -Z build-std=std,panic_abort \
-  --manifest-path caci/Cargo.toml \
-  --target wasm64-unknown-unknown \
-  --no-default-features \
-  --features "crypto_webcrypto" \
-  --release
-wasm-bindgen --target web \
-  --out-dir demos/caci-attestation-verify/caci_pkg \
-  target/wasm64-unknown-unknown/release/tee_attestation_verification_caci.wasm
+(
+  cd caci
+  wasm-pack build \
+    --target web \
+    --out-dir ../demos/caci-attestation-verify/caci_pkg \
+    --no-default-features \
+    --features "crypto_webcrypto"
+)
 ```
 
 Install JS dependencies and run:


### PR DESCRIPTION
Tahina recently removed the dependency in evercbor on 64bit addresses. This is great as it allows us to target 32 bit platforms such as wasm32.

~However this has not yet been released, so for now we pin to the specific commit which applies this. When there is a release we'll move over to that.~
Update: Now released and pinned to that release.