### PR TITLE
Add license-header check script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
       - name: Check Cargo versions match changelog
         run: python3 scripts/check-version-sync.py --root-path "${{ github.workspace }}"
 
+  license-headers:
+    name: License headers
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check license headers
+        run: scripts/check-license-headers.sh "${{ github.workspace }}"
+
   format:
     name: Format check
     runs-on: ubuntu-latest

--- a/caci/build.rs
+++ b/caci/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(sync_crypto)");
     println!("cargo:rustc-check-cfg=cfg(async_crypto)");

--- a/cose/build.rs
+++ b/cose/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(sync_crypto)");
     println!("cargo:rustc-check-cfg=cfg(async_crypto)");

--- a/cose/src/cbor.rs
+++ b/cose/src/cbor.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use cborrs::cbordet::*;
 use cborrs_nondet::cbornondet::*;
 

--- a/cose/src/cose.rs
+++ b/cose/src/cose.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 use crate::cbor::{serialize_array, CborSlice, CborValue};
 #[cfg(async_crypto)]
 use crypto::AsyncCryptoBackend;

--- a/cose/src/lib.rs
+++ b/cose/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 //! COSE_Sign1 verification backed by `tee-attestation-verification-crypto`.
 //!
 //! This crate is intentionally verification-only. It exposes:

--- a/crypto/src/x509_policy.rs
+++ b/crypto/src/x509_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #![allow(dead_code)]
 
 use std::time::Duration;

--- a/include/tav/caci.h
+++ b/include/tav/caci.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <stddef.h>

--- a/include/tav/cose.h
+++ b/include/tav/cose.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <stdbool.h>

--- a/include/tav/tav.h
+++ b/include/tav/tav.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #pragma once
 
 #include <stddef.h>

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Checks that every source file of a known type carries the standard two-line
+# license/copyright header:
+#
+#   <comment> Copyright (c) Microsoft Corporation.
+#   <comment> Licensed under the MIT License.
+#
+# The comment marker is `#` for .py/.sh and `//` for .rs/.c/.h/.cpp/.hpp/.js.
+# A leading shebang (`#!...`) line is allowed before the header.
+#
+# Usage: scripts/check-license-headers.sh [root]
+#   root defaults to the repository root (the script's parent directory).
+#
+# Exits 0 when every checked file is compliant, or 1 while listing offenders.
+
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+COPYRIGHT="Copyright (c) Microsoft Corporation."
+LICENSE="Licensed under the MIT License."
+
+missing=()
+checked=0
+
+while IFS= read -r -d '' file; do
+  case "$file" in
+    *.py | *.sh) prefix='#' ;;
+    *) prefix='//' ;;
+  esac
+
+  # Read the first three lines so the header can be found after an optional
+  # shebang line.
+  mapfile -t lines < <(head -n 3 "$file")
+  if [[ "${lines[0]:-}" == '#!'* ]]; then
+    line1="${lines[1]:-}"
+    line2="${lines[2]:-}"
+  else
+    line1="${lines[0]:-}"
+    line2="${lines[1]:-}"
+  fi
+
+  # Tolerate CRLF line endings.
+  line1="${line1%$'\r'}"
+  line2="${line2%$'\r'}"
+
+  if [[ "$line1" != "$prefix $COPYRIGHT" || "$line2" != "$prefix $LICENSE" ]]; then
+    missing+=("${file#"$ROOT"/}")
+  fi
+  checked=$((checked + 1))
+done < <(
+  find "$ROOT" \
+    \( -path '*/.git' \
+    -o -path '*/target' \
+    -o -path '*/node_modules' \
+    -o -path '*/dist' \
+    -o -path '*/pkg' \
+    -o -path '*/caci_pkg' \
+    -o -path '*/vendor' \) -prune -o \
+    -type f \( \
+    -name '*.py' \
+    -o -name '*.rs' \
+    -o -name '*.c' \
+    -o -name '*.h' \
+    -o -name '*.cpp' \
+    -o -name '*.hpp' \
+    -o -name '*.js' \
+    -o -name '*.sh' \) -print0
+)
+
+if ((${#missing[@]} > 0)); then
+  echo "Missing or malformed license header in ${#missing[@]} of ${checked} file(s):" >&2
+  for f in "${missing[@]}"; do
+    echo "  ${f}" >&2
+  done
+  exit 1
+fi
+
+echo "All ${checked} checked file(s) have the expected license header."


### PR DESCRIPTION
Adds `scripts/check-license-headers.sh`: finds every
`.py/.rs/.c/.h/.cpp/.hpp/.js/.sh` file (pruning `target`/`node_modules`/
`vendor`/`dist`/`pkg`) and checks each has the standard header —

```
<comment> Copyright (c) Microsoft Corporation.
<comment> Licensed under the MIT License.
```

— with the right marker per type (`#` for py/sh, `//` otherwise) and an
optional leading shebang. Exits non-zero listing any offenders.

**Commits**
1. Add the checker script.
2. Prepend the header to the 9 files that lacked it (`build.rs` ×2, several
   `cose/src/*.rs`, `crypto/src/x509_policy.rs`, `include/tav/*.h`) and add a
   `license-headers` CI job that runs the script.

Repo is fully compliant (55/55) and the check is now enforced in CI.
