### PR TITLE
Pin Rust toolchain and capture compiler info for WASM releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,29 @@ jobs:
 
           tar -C ../dist -czf "../release-artifacts/tav-caci-${VERSION}.tar.gz" tav-caci
 
+      - name: Capture build toolchain info
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p release-artifacts
+          {
+            echo "# Build toolchain used for TAV WASM release artifacts"
+            echo "version: ${VERSION}"
+            echo "commit: ${{ needs.prepare_release.outputs.commit_sha }}"
+            echo
+            echo "## rustc"
+            rustc --version --verbose
+            echo
+            echo "## cargo"
+            cargo --version --verbose
+            echo
+            echo "## wasm-pack"
+            wasm-pack --version
+          } > release-artifacts/BUILD-INFO.txt
+
+          cat release-artifacts/BUILD-INFO.txt
+
       - name: Generate release artifact checksums
         shell: bash
         run: |
@@ -211,7 +234,7 @@ jobs:
 
           (
             cd release-artifacts
-            sha256sum tav-attestation-${VERSION}.tar.gz tav-caci-${VERSION}.tar.gz > SHA256SUMS
+            sha256sum tav-attestation-${VERSION}.tar.gz tav-caci-${VERSION}.tar.gz BUILD-INFO.txt > SHA256SUMS
           )
 
       - name: Upload WASM release artifacts

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,8 @@
+# Pin the Rust toolchain for reproducible builds, in particular the WASM
+# release artifacts (see #66). rustup honours this file for every in-tree
+# cargo/rustc invocation, so CI, release, and local builds all use the same
+# compiler. Bump deliberately when adopting a newer stable.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Add a rust-toolchain.toml pinning the compiler (channel 1.96.0, wasm32 target) so CI, release, and local builds share one toolchain.
Addresses some of the reproducibility half of #66 (compiler pin + capture).