### PR TITLE
docs: add workspace dependency diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Read the crate-specific docs for API details:
 
 ## Component dependencies
 
-Arrows point from each crate to the workspace crates it directly depends on.
+Arrows point from each dependency to the workspace crates that directly depend on it.
 
 ```mermaid
 flowchart LR
@@ -37,15 +37,15 @@ flowchart LR
     crypto[crypto]
     ffi[ffi]
 
-    attestation --> crypto
-    caci --> attestation
-    caci --> cose
-    caci --> crypto
-    cose --> crypto
-    ffi --> attestation
-    ffi --> caci
-    ffi --> cose
-    ffi --> crypto
+    crypto --> attestation
+    attestation --> caci
+    cose --> caci
+    crypto --> caci
+    crypto --> cose
+    attestation --> ffi
+    caci --> ffi
+    cose --> ffi
+    crypto --> ffi
 ```
 
 ## Crypto backend selection

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ Read the crate-specific docs for API details:
 - [`caci/README.md`](caci/README.md)
 - [`ffi/README.md`](ffi/README.md)
 
+## Component dependencies
+
+Arrows point from each crate to the workspace crates it directly depends on.
+
+```mermaid
+flowchart LR
+    attestation["attestation (SNP)"]
+    caci[caci]
+    cose[cose]
+    crypto[crypto]
+    ffi[ffi]
+
+    attestation --> crypto
+    caci --> attestation
+    caci --> cose
+    caci --> crypto
+    cose --> crypto
+    ffi --> attestation
+    ffi --> caci
+    ffi --> cose
+    ffi --> crypto
+```
+
 ## Crypto backend selection
 
 To be compliant in multiple environments, we provide backends using openssl and webcrypto, as well as a pure rust backend.


### PR DESCRIPTION
## Summary

- document direct dependencies between the five Rust workspace crates
- identify the attestation crate as the SNP component
- clarify dependency-arrow direction

## Testing

Not run (documentation-only change).