### PR TITLE
Standardise CI runners on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci-attestation.yml
+++ b/.github/workflows/ci-attestation.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   wasm:
     name: WASM build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,7 +34,7 @@ jobs:
 
   native:
     name: Native build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-caci.yml
+++ b/.github/workflows/ci-caci.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   native:
     name: Native ${{ matrix.backend.name }} backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-cose.yml
+++ b/.github/workflows/ci-cose.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   native:
     name: Native build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-crypto.yml
+++ b/.github/workflows/ci-crypto.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   native:
     name: Native ${{ matrix.backend.name }} backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
 
   wasm:
     name: WASM ${{ matrix.backend.name }} backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-demo.yml
+++ b/.github/workflows/ci-demo.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   web-verify-kernel:
     name: web-verify-kernel e2e
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,7 +60,7 @@ jobs:
 
   caci-attestation-verify:
     name: E2E test of CACI attestation verification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -104,7 +104,7 @@ jobs:
 
   c-ffi:
     name: C FFI demo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -117,7 +117,7 @@ jobs:
 
   caci-c-ffi:
     name: CACI C FFI demo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci-ffi.yml
+++ b/.github/workflows/ci-ffi.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   native:
     name: Native ${{ matrix.backend.name }} backend
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -41,7 +41,7 @@ jobs:
 
   ffi-wasm-api:
     name: FFI WASM API consumer tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -69,7 +69,7 @@ jobs:
 
   ffi-c-api:
     name: FFI C API consumer tests (${{ matrix.backend.name }}, ${{ matrix.link }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,23 @@ permissions:
 jobs:
   version-sync:
     name: Version sync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # check-version-sync.py needs tomllib, which is only in the standard library
+      # from Python 3.11. Ubuntu 22.04 ships 3.10, so request an explicit version.
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
 
       - name: Check Cargo versions match changelog
         run: python3 scripts/check-version-sync.py --root-path "${{ github.workspace }}"
 
   license-headers:
     name: License headers
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -36,7 +42,7 @@ jobs:
 
   format:
     name: Format check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -49,7 +55,7 @@ jobs:
 
   docs-build:
     name: Docs build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   prepare_release:
     name: Prepare release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       version: ${{ steps.prepare.outputs.version }}
@@ -92,7 +92,7 @@ jobs:
 
   package_wasm:
     name: Package WASM artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare_release
     env:
       VERSION: ${{ needs.prepare_release.outputs.version }}
@@ -171,7 +171,7 @@ jobs:
 
   create_release:
     name: Create release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - prepare_release
       - ci


### PR DESCRIPTION
## Summary

Pin every workflow job to `ubuntu-22.04` instead of `ubuntu-latest`.

`ubuntu-latest` currently resolves to Ubuntu 24.04, which ships glibc 2.39. Anything compiled there may record symbol versions that do not exist on older distributions, so CI was not exercising the oldest environment the project claims to support. A dependency that raised the glibc floor would pass every check and only surface when a consumer tried to load the artifact.

Pinning gives builds and tests a single baseline, and each workflow now carries a short comment explaining the choice so the pin is not casually reverted.

## Why 22.04

It is the oldest baseline currently targeted by the released artifacts. This does mean CI no longer exercises newer glibc; that is the intended trade, since the released binary is the one that has to load on the widest range of hosts.

## Validation

All eight workflow files parse. The real check is this PR's own CI run, which exercises every pinned job.

Raised out of the review on #79 and deliberately kept separate from it.
