### PR TITLE
Make tav_cbor_value_kind fallible

### DIFF
--- a/ffi/include/tav/cose.h
+++ b/ffi/include/tav/cose.h
@@ -38,6 +38,9 @@ extern "C" {
  */
 
 typedef enum TavCborKind {
+    /* Never returned on success; the value an out-parameter is reset to
+     * before fallible work. */
+    TAV_CBOR_KIND_INVALID = 0,
     TAV_CBOR_KIND_INT = 1,
     TAV_CBOR_KIND_SIMPLE = 2,
     TAV_CBOR_KIND_BYTES = 3,
@@ -92,8 +95,10 @@ TAV_COSE_API TavError *tav_cbor_value_to_bytes(
     const TavCborValue *value,
     TavByteBuffer **out_bytes);
 
-/* value must be a valid, non-NULL TavCborValue handle. */
-TAV_COSE_API TavCborKind tav_cbor_value_kind(const TavCborValue *value);
+/* Writes the CBOR major type of value to out_kind. */
+TAV_COSE_API TavError *tav_cbor_value_kind(
+    const TavCborValue *value,
+    TavCborKind *out_kind);
 
 TAV_COSE_API TavError *tav_cbor_value_int(
     const TavCborValue *value,

--- a/ffi/src/c_ffi/README.md
+++ b/ffi/src/c_ffi/README.md
@@ -4,14 +4,16 @@ Native C ABI for SNP, COSE, and CACI verification. Headers live under
 `ffi/include/tav/`; each header's usage summary documents its own surface in
 more detail (`snp.h`, `cose.h`, `caci.h`, `utils.h`).
 
-All public functions return `NULL` on success or an owned `TavError*` on
-failure. Inspect failures with `tav_error_code`/`tav_error_message`, then free
-them with `tav_error_free`. Owned handle out-parameters are reset to `NULL`
+All public functions except the null-safe `tav_*_free` destructors return `NULL`
+on success or an owned `TavError*` on failure. Inspect failures with
+`tav_error_code`/`tav_error_message`, then free them with `tav_error_free`.
+Handle out-parameters are reset to `NULL`, and scalar out-parameters to zero,
 before any fallible work and set only on success.
 
-If an entry point's implementation panics (e.g. on a bug triggered by
-malformed input), the panic is caught at the FFI boundary and reported as a
-`TAV_ERROR_PANIC` error instead of aborting the host process.
+Passing a null handle is reported as `TAV_ERROR_INVALID_ARGUMENT` rather than
+dereferenced. If an entry point's implementation panics (e.g. on a bug
+triggered by malformed input), the panic is caught at the FFI boundary and
+reported as a `TAV_ERROR_PANIC` error instead of aborting the host process.
 
 ## Building and linking
 
@@ -39,7 +41,8 @@ tav_cbor_value_from_bytes(cbor, cbor_len, &root);
 tav_cbor_value_array_at(root, 0, &child);
 
 tav_cbor_value_free(root); /* child remains valid */
-TavCborKind kind = tav_cbor_value_kind(child);
+TavCborKind kind = TAV_CBOR_KIND_INVALID;
+tav_cbor_value_kind(child, &kind);
 tav_cbor_value_free(child);
 ```
 

--- a/ffi/src/c_ffi/cose.rs
+++ b/ffi/src/c_ffi/cose.rs
@@ -21,8 +21,12 @@ use crypto::{CryptoBackend, KeyBackend};
 use cose::{cose_sign1, signature_key_algorithm_for_cose_alg, CborValue as NativeCborValue};
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum TavCborKind {
+    /// Never returned on success; the value an out-parameter is reset to
+    /// before fallible work.
+    #[default]
+    Invalid = 0,
     Int = 1,
     Simple = 2,
     Bytes = 3,
@@ -179,8 +183,18 @@ pub unsafe extern "C" fn tav_cbor_value_to_bytes(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn tav_cbor_value_kind(value: *const TavCborValue) -> TavCborKind {
-    kind(unsafe { (*value).as_native() })
+pub unsafe extern "C" fn tav_cbor_value_kind(
+    value: *const TavCborValue,
+    out: *mut TavCborKind,
+) -> *mut TavError {
+    into_result(|| {
+        unsafe { scalar_out_ptr(out, "out") }?;
+        let value = unsafe { cbor_value(value, "value") }?;
+        unsafe {
+            *out = kind(value);
+        }
+        Ok(())
+    })
 }
 
 #[no_mangle]
@@ -649,6 +663,7 @@ mod tests {
         let header = include_str!("../../include/tav/cose.h");
 
         for (name, value) in [
+            ("TAV_CBOR_KIND_INVALID", TavCborKind::Invalid as i32),
             ("TAV_CBOR_KIND_INT", TavCborKind::Int as i32),
             ("TAV_CBOR_KIND_SIMPLE", TavCborKind::Simple as i32),
             ("TAV_CBOR_KIND_BYTES", TavCborKind::Bytes as i32),

--- a/ffi/tests/c-consumer/cose.cpp
+++ b/ffi/tests/c-consumer/cose.cpp
@@ -7,6 +7,8 @@
 
 #include <cstring>
 
+using namespace tav_test;
+
 namespace {
 
 // COSE P-256 verification-only vector, mirrored from the in-crate Rust tests.
@@ -75,7 +77,7 @@ TEST_CASE("cbor: array children are independently owned views") {
 
     CborHandle child;
     REQUIRE(tav_cbor_value_array_at(root.value, 0, child.out()) == nullptr);
-    CHECK(tav_cbor_value_kind(child.value) == TAV_CBOR_KIND_INT);
+    CHECK(cbor_kind(child.value) == TAV_CBOR_KIND_INT);
     int64_t as_int = 0;
     REQUIRE(tav_cbor_value_int(child.value, &as_int) == nullptr);
     CHECK(as_int == 1);
@@ -137,6 +139,18 @@ TEST_CASE("cbor: failed accessors clear their out-parameters") {
     CHECK(scalar == 0);
     tav_error_free(error);
 
+    // Null handle: reading the kind reports an error rather than dereferencing.
+    TavCborKind kind = TAV_CBOR_KIND_TAGGED;
+    error = tav_cbor_value_kind(nullptr, &kind);
+    CHECK(tav_error_code(error) == TAV_ERROR_INVALID_ARGUMENT);
+    CHECK(kind == TAV_CBOR_KIND_INVALID);
+    tav_error_free(error);
+
+    // Null out-parameter is rejected too.
+    error = tav_cbor_value_kind(root.value, nullptr);
+    CHECK(tav_error_code(error) == TAV_ERROR_INVALID_ARGUMENT);
+    tav_error_free(error);
+
     // Out-of-range map entry on a non-map clears both handles.
     TavCborValue *key = reinterpret_cast<TavCborValue *>(0x1);
     TavCborValue *value = reinterpret_cast<TavCborValue *>(0x1);
@@ -177,7 +191,7 @@ TEST_CASE("cbor: map lookup and presence checks") {
     CborHandle bstr_key;
     REQUIRE(tav_cbor_value_map_entry_at(root.value, 2, bstr_key.out(), value.out()) == nullptr);
     REQUIRE(tav_cbor_value_map_at(root.value, bstr_key.value, value.out()) == nullptr);
-    CHECK(tav_cbor_value_kind(value.value) == TAV_CBOR_KIND_SIMPLE);
+    CHECK(cbor_kind(value.value) == TAV_CBOR_KIND_SIMPLE);
 
     // A freshly parsed equivalent key still matches by structural equality.
     const uint8_t key_cbor[] = {0x41, 0xaa};
@@ -289,7 +303,7 @@ TEST_CASE("cbor: simple value extraction") {
     const uint8_t cbor[] = {0xf5};
     CborHandle root;
     REQUIRE(tav_cbor_value_from_bytes(cbor, sizeof(cbor), &root.value) == nullptr);
-    CHECK(tav_cbor_value_kind(root.value) == TAV_CBOR_KIND_SIMPLE);
+    CHECK(cbor_kind(root.value) == TAV_CBOR_KIND_SIMPLE);
 
     uint8_t simple = 0;
     REQUIRE(tav_cbor_value_simple(root.value, &simple) == nullptr);
@@ -311,7 +325,7 @@ TEST_CASE("cbor: tag number and tagged payload") {
     std::vector<uint8_t> env = build_sign1(/*embedded_payload=*/true);
     CborHandle root;
     REQUIRE(tav_cbor_value_from_bytes(env.data(), env.size(), &root.value) == nullptr);
-    CHECK(tav_cbor_value_kind(root.value) == TAV_CBOR_KIND_TAGGED);
+    CHECK(cbor_kind(root.value) == TAV_CBOR_KIND_TAGGED);
 
     uint64_t tag = 0;
     REQUIRE(tav_cbor_value_tag(root.value, &tag) == nullptr);
@@ -320,7 +334,7 @@ TEST_CASE("cbor: tag number and tagged payload") {
     CborHandle payload;
     REQUIRE(tav_cbor_value_tagged_payload(root.value, payload.out()) == nullptr);
     REQUIRE(payload.value != nullptr);
-    CHECK(tav_cbor_value_kind(payload.value) == TAV_CBOR_KIND_ARRAY);
+    CHECK(cbor_kind(payload.value) == TAV_CBOR_KIND_ARRAY);
     size_t payload_len = 0;
     REQUIRE(tav_cbor_value_len(payload.value, &payload_len) == nullptr);
     CHECK(payload_len == 4);
@@ -347,7 +361,7 @@ TEST_CASE("cose: embedded COSE_Sign1 verification succeeds") {
     CborHandle sign1;
     REQUIRE(tav_validate_cose_sign1(root.value, sign1.out()) == nullptr);
     REQUIRE(sign1.value != nullptr);
-    CHECK(tav_cbor_value_kind(sign1.value) == TAV_CBOR_KIND_ARRAY);
+    CHECK(cbor_kind(sign1.value) == TAV_CBOR_KIND_ARRAY);
 
     TavError *error = tav_verify_cose_sign1_embedded(
         sign1.value, kSpki.data(), kSpki.size(), TAV_COSE_ALG_ES256);

--- a/ffi/tests/c-consumer/support.h
+++ b/ffi/tests/c-consumer/support.h
@@ -30,6 +30,14 @@ namespace tav_test {
 // Mirrors c_ffi::utils::MAX_INPUT_LEN (1 GiB); not exported by the headers.
 constexpr size_t kMaxInputLen = 1024ull * 1024ull * 1024ull;
 
+// Reads a CBOR handle's kind, asserting the call succeeds, so that positive
+// assertions stay readable.
+inline TavCborKind cbor_kind(const TavCborValue *value) {
+    TavCborKind kind = TAV_CBOR_KIND_INVALID;
+    REQUIRE(tav_cbor_value_kind(value, &kind) == nullptr);
+    return kind;
+}
+
 inline std::vector<uint8_t> read_file(const std::string &relative) {
     std::string path = std::string(TAV_REPO_ROOT) + "/" + relative;
     FILE *file = std::fopen(path.c_str(), "rb");


### PR DESCRIPTION
## Summary

`tav_cbor_value_kind` returned `TavCborKind` directly:

```c
TAV_COSE_API TavCborKind tav_cbor_value_kind(const TavCborValue *value);
```

With no error channel it could not report a null handle, so it dereferenced one:

```rust
kind(unsafe { (*value).as_native() })
```

It was the only CBOR accessor without an error channel; every other one null-checks and returns a `TavError *`. Panic handling does not help here, because dereferencing null is undefined behaviour rather than a catchable panic — the header simply required callers to guarantee a non-NULL handle.

## Change

```c
TAV_COSE_API TavError *tav_cbor_value_kind(
    const TavCborValue *value,
    TavCborKind *out_kind);
```

`TAV_CBOR_KIND_INVALID = 0` is added so the out-parameter has a defined value to reset to before fallible work, which is what the existing scalar out-parameter convention requires. It is never returned on success.

## Validation

- C consumer suite: 23 cases, 276 assertions, all passing, including new checks that a null handle and a null out-parameter each return `TAV_ERROR_INVALID_ARGUMENT` and that the out-parameter is reset to `TAV_CBOR_KIND_INVALID`.
- Confirmed directly against the built library that a null handle now returns `code=1 value is null` with `kind=0`, where the previous signature dereferenced null.
- `cargo test -p tee-attestation-verification-ffi`, `cargo fmt --all -- --check`.

## Note on the ABI equivalence test

Adding a variant to both the Rust enum and the C header did **not** fail `c_header_enums_match_rust_enums`. That test is a hand-maintained allowlist, so it catches a mismatched or missing constant but not an extra one on either side. The new variant is added to the list here; making the check reject additions is left as separate work.

## Breaking

This changes the C ABI signature. There are no known consumers outside this repository, and the in-tree C consumer tests and documentation are updated. The WASM and C# bindings do not use this entry point.
