### PR TITLE
Name the COSE algorithm identifiers and check every ABI constant

### DIFF
--- a/cose/src/cose.rs
+++ b/cose/src/cose.rs
@@ -36,6 +36,15 @@ pub const CWT_CLAIMS_ISSUER: i64 = 1;
 pub const CWT_CLAIMS_SUBJECT: i64 = 2;
 pub const CWT_CLAIMS_IAT: i64 = 6;
 
+// IANA COSE Algorithms registry
+// https://www.iana.org/assignments/cose/cose.xhtml#algorithms
+pub const COSE_ALG_ES256: i64 = -7;
+pub const COSE_ALG_ES384: i64 = -35;
+pub const COSE_ALG_ES512: i64 = -36;
+pub const COSE_ALG_PS256: i64 = -37;
+pub const COSE_ALG_PS384: i64 = -38;
+pub const COSE_ALG_PS512: i64 = -39;
+
 /// Return the COSE_Sign1 array from a tagged or untagged COSE_Sign1 document.
 pub fn cose_sign1(document: &CborValue) -> Result<&CborValue, String> {
     // RFC 9052, Section 4.2: COSE_Sign1 may be encoded as CBOR tag 18
@@ -75,21 +84,21 @@ pub fn cose_sign1(document: &CborValue) -> Result<&CborValue, String> {
 pub fn signature_key_algorithm_for_cose_alg(alg: i64) -> Result<SignatureKeyAlgorithm, String> {
     match alg {
         // ES256. RFC 9053, Section 2.1; IANA COSE Algorithms value -7.
-        -7 => Ok(SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P256)),
+        COSE_ALG_ES256 => Ok(SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P256)),
         // ES384. RFC 9053, Section 2.1; IANA COSE Algorithms value -35.
-        -35 => Ok(SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P384)),
+        COSE_ALG_ES384 => Ok(SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P384)),
         // ES512. RFC 9053, Section 2.1; IANA COSE Algorithms value -36.
-        -36 => Ok(SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P521)),
+        COSE_ALG_ES512 => Ok(SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P521)),
         // PS256. RFC 8230, Section 2; IANA COSE Algorithms value -37.
-        -37 => Ok(SignatureKeyAlgorithm::RsaPss(
+        COSE_ALG_PS256 => Ok(SignatureKeyAlgorithm::RsaPss(
             RsaPssSignatureKeyAlgorithm::Ps256,
         )),
         // PS384. RFC 8230, Section 2; IANA COSE Algorithms value -38.
-        -38 => Ok(SignatureKeyAlgorithm::RsaPss(
+        COSE_ALG_PS384 => Ok(SignatureKeyAlgorithm::RsaPss(
             RsaPssSignatureKeyAlgorithm::Ps384,
         )),
         // PS512. RFC 8230, Section 2; IANA COSE Algorithms value -39.
-        -39 => Ok(SignatureKeyAlgorithm::RsaPss(
+        COSE_ALG_PS512 => Ok(SignatureKeyAlgorithm::RsaPss(
             RsaPssSignatureKeyAlgorithm::Ps512,
         )),
         _ => Err(format!("{alg} is not a supported COSE signature algorithm")),
@@ -101,12 +110,12 @@ pub fn cose_alg_for_signature_key_algorithm(
     algorithm: SignatureKeyAlgorithm,
 ) -> Result<i64, String> {
     match algorithm {
-        SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P256) => Ok(-7),
-        SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P384) => Ok(-35),
-        SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P521) => Ok(-36),
-        SignatureKeyAlgorithm::RsaPss(RsaPssSignatureKeyAlgorithm::Ps256) => Ok(-37),
-        SignatureKeyAlgorithm::RsaPss(RsaPssSignatureKeyAlgorithm::Ps384) => Ok(-38),
-        SignatureKeyAlgorithm::RsaPss(RsaPssSignatureKeyAlgorithm::Ps512) => Ok(-39),
+        SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P256) => Ok(COSE_ALG_ES256),
+        SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P384) => Ok(COSE_ALG_ES384),
+        SignatureKeyAlgorithm::Ec(EcSignatureKeyAlgorithm::P521) => Ok(COSE_ALG_ES512),
+        SignatureKeyAlgorithm::RsaPss(RsaPssSignatureKeyAlgorithm::Ps256) => Ok(COSE_ALG_PS256),
+        SignatureKeyAlgorithm::RsaPss(RsaPssSignatureKeyAlgorithm::Ps384) => Ok(COSE_ALG_PS384),
+        SignatureKeyAlgorithm::RsaPss(RsaPssSignatureKeyAlgorithm::Ps512) => Ok(COSE_ALG_PS512),
         _ => Err(format!(
             "Unsupported signature key algorithm {:?} for COSE",
             algorithm

--- a/ffi/src/c_ffi/cose.rs
+++ b/ffi/src/c_ffi/cose.rs
@@ -648,7 +648,7 @@ mod tests {
     fn c_header_enums_match_rust_enums() {
         let header = include_str!("../../include/tav/cose.h");
 
-        for (name, value) in [
+        let expected = [
             ("TAV_CBOR_KIND_INT", TavCborKind::Int as i32),
             ("TAV_CBOR_KIND_SIMPLE", TavCborKind::Simple as i32),
             ("TAV_CBOR_KIND_BYTES", TavCborKind::Bytes as i32),
@@ -656,6 +656,12 @@ mod tests {
             ("TAV_CBOR_KIND_ARRAY", TavCborKind::Array as i32),
             ("TAV_CBOR_KIND_MAP", TavCborKind::Map as i32),
             ("TAV_CBOR_KIND_TAGGED", TavCborKind::Tagged as i32),
+            ("TAV_COSE_ALG_ES256", cose::COSE_ALG_ES256 as i32),
+            ("TAV_COSE_ALG_ES384", cose::COSE_ALG_ES384 as i32),
+            ("TAV_COSE_ALG_ES512", cose::COSE_ALG_ES512 as i32),
+            ("TAV_COSE_ALG_PS256", cose::COSE_ALG_PS256 as i32),
+            ("TAV_COSE_ALG_PS384", cose::COSE_ALG_PS384 as i32),
+            ("TAV_COSE_ALG_PS512", cose::COSE_ALG_PS512 as i32),
             ("TAV_COSE_TAG_SIGN1", cose::COSE_SIGN1_TAG as i32),
             (
                 "TAV_COSE_SIGN1_PROTECTED",
@@ -687,24 +693,41 @@ mod tests {
             ("TAV_CWT_CLAIMS_ISSUER", cose::CWT_CLAIMS_ISSUER as i32),
             ("TAV_CWT_CLAIMS_SUBJECT", cose::CWT_CLAIMS_SUBJECT as i32),
             ("TAV_CWT_CLAIMS_IAT", cose::CWT_CLAIMS_IAT as i32),
-        ] {
+        ];
+
+        for (name, value) in expected {
             assert_eq!(
                 c_header_enum_value(header, name),
                 Some(value),
                 "{name} in ffi/include/tav/cose.h must match Rust"
             );
         }
+
+        let header_names: std::collections::BTreeSet<&str> = header
+            .lines()
+            .filter_map(|line| {
+                let (name, _) = line.trim().split_once('=')?;
+                let name = name.trim();
+                (name.starts_with("TAV_CBOR_KIND_")
+                    || name.starts_with("TAV_COSE_")
+                    || name.starts_with("TAV_CWT_"))
+                .then_some(name)
+            })
+            .collect();
+        let expected_names: std::collections::BTreeSet<&str> =
+            expected.iter().map(|(name, _)| *name).collect();
+        assert_eq!(
+            header_names, expected_names,
+            "ffi/include/tav/cose.h ABI constants must exactly match the checked Rust set"
+        );
     }
 
     fn c_header_enum_value(header: &str, name: &str) -> Option<i32> {
-        let line = header
-            .lines()
-            .find(|line| line.trim_start().starts_with(name))?;
-        line.split('=')
-            .nth(1)?
-            .trim()
-            .trim_end_matches(',')
-            .parse()
-            .ok()
+        header.lines().find_map(|line| {
+            let (lhs, rhs) = line.split_once('=')?;
+            (lhs.trim() == name)
+                .then(|| rhs.trim().trim_end_matches(',').parse().ok())
+                .flatten()
+        })
     }
 }


### PR DESCRIPTION
Declares the six COSE algorithm identifiers as `COSE_ALG_*` in `cose` and uses them in both directions of the `SignatureKeyAlgorithm` mapping, replacing bare integers whose names lived only in comments.

Makes `c_header_enums_match_rust_enums` exhaustive. It verified that every constant it pinned matched Rust, but not that it pinned every constant — the `TAV_COSE_ALG_*` values sat in `ffi/include/tav/cose.h` unchecked. It now asserts set equality between the `TAV_CBOR_KIND_*`, `TAV_COSE_*` and `TAV_CWT_*` constants the header declares and the set it pins, so an unpinned header constant fails.

Constant lookup also matches names exactly rather than by prefix. No header name is currently a prefix of another, so this fixes no live bug.

No behaviour change.

### Validation

- `cargo test --locked -p tee-attestation-verification-cose -p tee-attestation-verification-ffi` — 58 pass
- `cargo fmt --all --check`, `check-license-headers.sh`, `check-version-sync.py` — clean
- Adding a `TAV_COSE_ALG_BOGUS` constant to the header fails the new assertion