### PR TITLE
Add stable required CI gates

### DIFF
--- a/.github/workflows/ci-attestation.yml
+++ b/.github/workflows/ci-attestation.yml
@@ -53,3 +53,17 @@ jobs:
 
       - name: Test native with KDS
         run: cargo test --manifest-path attestation/Cargo.toml --no-default-features --features "crypto_pure_rust,kds" -- --nocapture
+
+  required:
+    name: Attestation CI required
+    if: always()
+    needs:
+      - wasm
+      - native
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"

--- a/.github/workflows/ci-caci.yml
+++ b/.github/workflows/ci-caci.yml
@@ -38,3 +38,16 @@ jobs:
 
       - name: Test with ${{ matrix.backend.name }} backend
         run: cargo test --manifest-path caci/Cargo.toml --no-default-features --features "${{ matrix.backend.features }}" -- --nocapture
+
+  required:
+    name: CACI attestation verification CI required
+    if: always()
+    needs:
+      - native
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"

--- a/.github/workflows/ci-cose.yml
+++ b/.github/workflows/ci-cose.yml
@@ -29,3 +29,16 @@ jobs:
 
       - name: Test native with pure-Rust backend
         run: cargo test --manifest-path cose/Cargo.toml --no-default-features --features "crypto_pure_rust" -- --nocapture
+
+  required:
+    name: COSE CI required
+    if: always()
+    needs:
+      - native
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"

--- a/.github/workflows/ci-crypto.yml
+++ b/.github/workflows/ci-crypto.yml
@@ -67,3 +67,17 @@ jobs:
       - name: Test ${{ matrix.backend.name }} backend
         working-directory: crypto
         run: wasm-pack test --node --no-default-features --features "${{ matrix.backend.features }}"
+
+  required:
+    name: Crypto CI required
+    if: always()
+    needs:
+      - native
+      - wasm
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"

--- a/.github/workflows/ci-demo.yml
+++ b/.github/workflows/ci-demo.yml
@@ -127,3 +127,19 @@ jobs:
 
       - name: Run CACI C FFI demo tests
         run: python3 demos/caci-c-ffi/run_tests.py
+
+  required:
+    name: Demo CI required
+    if: always()
+    needs:
+      - web-verify-kernel
+      - caci-attestation-verify
+      - c-ffi
+      - caci-c-ffi
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"

--- a/.github/workflows/ci-ffi.yml
+++ b/.github/workflows/ci-ffi.yml
@@ -123,3 +123,19 @@ jobs:
       - name: Run C# native API consumer tests
         shell: bash
         run: python3 ffi/csharp/run_tests.py --configuration Release
+
+  required:
+    name: FFI CI required
+    if: always()
+    needs:
+      - native
+      - ffi-wasm-api
+      - ffi-c-api
+      - ffi-csharp-api
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,19 @@ jobs:
 
       - name: WASM build docs
         run: cargo doc -p tee-attestation-verification-lib --target wasm32-unknown-unknown
+
+  required:
+    name: Workspace CI required
+    if: always()
+    needs:
+      - version-sync
+      - license-headers
+      - format
+      - docs-build
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: jq --exit-status 'all(.[]; .result == "success")' <<< "$NEEDS"


### PR DESCRIPTION
Adds one uniquely named aggregate required job to each CI workflow.

Each gate:
- runs with `always()` after every job in its workflow
- succeeds only when every dependency succeeds
- provides one stable, unambiguous status-check name

After merging, branch protection can require these seven checks instead of individual matrix jobs:

- `Workspace CI required`
- `Attestation CI required`
- `CACI attestation verification CI required`
- `COSE CI required`
- `Crypto CI required`
- `Demo CI required`
- `FFI CI required`

Validated with `actionlint` and a structural check covering dependencies and unique gate names.