### PR TITLE
Align the .NET README with C-ACI endorsements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.6]
+
+[1.0.6]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.6
+
+### Changed
+
+- Updated the NuGet package README to consume C-ACI's published endorsement formats directly. (#98)
+
 ## [1.0.5]
 
 [1.0.5]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-caci"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "serde_json",
  "tee-attestation-verification-cose",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-cose"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "cborrs",
  "cborrs-nondet",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-crypto"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "ecdsa",
  "foreign-types",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-ffi"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-lib"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "console_error_panic_hook",
  "curl",

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-lib"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -45,7 +45,7 @@ env_logger = "0.11"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.5", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
 zerocopy = {version = "0.8.31", features = ["derive"]}
 
 # KDS (online certificate fetching) dependencies

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-caci"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -32,9 +32,9 @@ crypto_webcrypto = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.5", path = "../attestation", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.5", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.5", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.6", path = "../attestation", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.6", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
 serde_json = "1"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-cose"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -16,7 +16,7 @@ crypto_pure_rust = ["crypto/crypto_pure_rust"]
 crypto_webcrypto = ["crypto/crypto_webcrypto"]
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.5", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
 # project-everest/everparse tag v2026.07.02 resolves to this pinned commit.
 cborrs = { git = "https://github.com/project-everest/everparse.git", rev = "950bc93838ac2faae51126d8acd0637cf8c8a569" }
 cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", rev = "950bc93838ac2faae51126d8acd0637cf8c8a569" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-crypto"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-ffi"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -33,10 +33,10 @@ crypto_webcrypto = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.5", path = "../attestation", default-features = false }
-caci = { package = "tee-attestation-verification-caci", version = "1.0.5", path = "../caci", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.5", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.5", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.6", path = "../attestation", default-features = false }
+caci = { package = "tee-attestation-verification-caci", version = "1.0.6", path = "../caci", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.6", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
 serde_json = "1"
 zerocopy = { version = "0.8.31", features = ["derive"] }
 

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -8,7 +8,7 @@ repository's native C ABI.
 Add the package from your configured NuGet feed:
 
 ```bash
-dotnet add package TeeAttestationVerification --version 1.0.5
+dotnet add package TeeAttestationVerification --version 1.0.6
 ```
 
 The runtime environment must provide:

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -102,9 +102,16 @@ sealed record AmdEndorsements(string ArkPem, string AskPem, string VcekPem);
 `VerifySnpAttestation` authenticates the AMD certificate chain and SNP report,
 `VerifyUvmEndorsement` authenticates `reference-info-base64`, and
 `VerifyCaciAttestation` applies the relying-party policy before returning the
-verified 64-byte report data. The policy digest and minimum SVN above match the
-checked-in demo fixture; replace them with independently managed relying-party
-configuration. Do not trust values merely because the workload supplied them.
+verified 64-byte report data. The trusted DID and UVM feed are the stable
+identifiers specified by the
+[Confidential ACI scheme](https://github.com/microsoft/confidential-aci-examples/blob/main/docs/Confidential_ACI_SCHEME.md#reference-info-base64).
+The policy digest and minimum SVN above come from the checked-in
+[demo manifest](https://github.com/microsoft/TEE-Attestation-Verification/blob/main/demos/caci-attestation-verify/test-data/manifest.json).
+Replace the demo values with independently managed relying-party configuration,
+and follow C-ACI's
+[platform update guidance](https://github.com/microsoft/confidential-aci-examples/blob/main/docs/Confidential_ACI_SCHEME.md#platform-update-timing)
+when setting a production minimum SVN. Do not trust values merely because the
+workload supplied them.
 
 Native calls fail with `DllNotFoundException` when the package does not carry a
 native asset for the running platform, or when the OpenSSL 3 runtime libraries

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -19,58 +19,92 @@ The runtime environment must provide:
 
 ## Verify a CACI attestation
 
+Confidential ACI publishes `host-amd-cert-base64` and
+`reference-info-base64` under its `UVM_SECURITY_CONTEXT_DIR`. Send those files
+and an SNP attestation report to the relying party. The example below uses a
+hex-encoded report, matching the
+[`caci-attestation-verify` demo](https://github.com/microsoft/TEE-Attestation-Verification/tree/main/demos/caci-attestation-verify).
+
 ```csharp
+using System.Text.Json;
 using TeeAttestationVerification;
 
-byte[] reportBytes = File.ReadAllBytes("attestation-report.bin");
-string arkPem = File.ReadAllText("ark.pem");
-string askPem = File.ReadAllText("ask.pem");
-string vcekPem = File.ReadAllText("vcek.pem");
-byte[] uvmEndorsement = File.ReadAllBytes("uvm-endorsement.cose");
-string trustedDidX509 = File.ReadAllText("trusted-did-x509.txt").Trim();
+const string TrustedDidX509 =
+    "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s" +
+    "::eku:1.3.6.1.4.1.311.76.59.1.2";
+const string TrustedUvmFeed = "ContainerPlat-AMD-UVM";
+const ulong MinimumUvmSvn = 104;
+
+// Evidence supplied by the C-ACI workload is untrusted until verified.
+byte[] reportBytes = ReadHexFile("attestation-report.hex");
+AmdEndorsements amd = ReadAmdEndorsements("host-amd-cert-base64");
+byte[] uvmEndorsement = ReadBase64File("reference-info-base64");
+
+// Relying-party policy must be configured independently of that evidence.
 ReadOnlyMemory<byte>[] trustedPolicyDigests =
 [
-    File.ReadAllBytes("trusted-caci-policy.sha256"),
+    Convert.FromHexString(
+        "4f4448c67f3c8dfc8de8a5e37125d807" +
+        "dadcc41f06cf23f615dbd52eec777d10"),
 ];
-(uint Cpuid, ReadOnlyMemory<byte> Tcb)[] minimumTcb =
-[
-    (0x00a00f11u, File.ReadAllBytes("minimum-tcb.bin")),
-];
-string uvmFeed = File.ReadAllText("uvm-feed.txt").Trim();
-ulong minimumSvn = ulong.Parse(File.ReadAllText("minimum-svn.txt"));
 
-try
+using SnpAttestationReport report = AttestationVerifier.VerifySnpAttestation(
+    reportBytes,
+    amd.ArkPem,
+    amd.AskPem,
+    amd.VcekPem);
+using CborValue uvm = AttestationVerifier.VerifyUvmEndorsement(
+    uvmEndorsement,
+    TrustedDidX509);
+
+byte[] reportData = AttestationVerifier.VerifyCaciAttestation(
+    report,
+    [], // The minimum TCB policy is omitted from this example.
+    trustedPolicyDigests,
+    uvm,
+    TrustedUvmFeed,
+    MinimumUvmSvn);
+
+Console.WriteLine(Convert.ToHexString(reportData));
+
+static AmdEndorsements ReadAmdEndorsements(string path)
 {
-    SnpAttestationReport report = AttestationVerifier.VerifySnpAttestation(
-        reportBytes,
-        arkPem,
-        askPem,
-        vcekPem);
-    CborValue uvm = AttestationVerifier.VerifyUvmEndorsement(
-        uvmEndorsement,
-        trustedDidX509);
+    using JsonDocument document = JsonDocument.Parse(ReadBase64File(path));
+    JsonElement root = document.RootElement;
+    string vcekPem = root.GetProperty("vcekCert").GetString()
+        ?? throw new FormatException("host AMD certificate JSON has no VCEK");
+    string chainPem = root.GetProperty("certificateChain").GetString()
+        ?? throw new FormatException("host AMD certificate JSON has no certificate chain");
 
-    byte[] reportData = AttestationVerifier.VerifyCaciAttestation(
-        report,
-        minimumTcb,
-        trustedPolicyDigests,
-        uvm,
-        uvmFeed,
-        minimumSvn);
+    // C-ACI publishes the certificate chain in ASK, ARK order.
+    IReadOnlyList<string> chain = AttestationVerifier.SplitPemBundle(chainPem);
+    if (chain.Count != 2)
+    {
+        throw new FormatException(
+            $"expected an ASK and ARK certificate, got {chain.Count}");
+    }
 
-    Console.WriteLine(Convert.ToHexString(reportData));
+    return new AmdEndorsements(chain[1], chain[0], vcekPem);
 }
-catch (VerifyException error)
-{
-    Console.Error.WriteLine($"{error.Code}: {error.Message}");
-}
+
+static byte[] ReadBase64File(string path) =>
+    Convert.FromBase64String(RemoveWhitespace(File.ReadAllText(path)));
+
+static byte[] ReadHexFile(string path) =>
+    Convert.FromHexString(RemoveWhitespace(File.ReadAllText(path)));
+
+static string RemoveWhitespace(string value) =>
+    string.Concat(value.Where(character => !char.IsWhiteSpace(character)));
+
+sealed record AmdEndorsements(string ArkPem, string AskPem, string VcekPem);
 ```
 
 `VerifySnpAttestation` authenticates the AMD certificate chain and SNP report,
-`VerifyUvmEndorsement` authenticates the UVM endorsement, and
+`VerifyUvmEndorsement` authenticates `reference-info-base64`, and
 `VerifyCaciAttestation` applies the relying-party policy before returning the
-verified 64-byte report data. Load the trusted DID, policy digests, minimum TCB,
-feed, and minimum SVN from relying-party configuration, not from the attester.
+verified 64-byte report data. The policy digest and minimum SVN above match the
+checked-in demo fixture; replace them with independently managed relying-party
+configuration. Do not trust values merely because the workload supplied them.
 
 Native calls fail with `DllNotFoundException` when the package does not carry a
 native asset for the running platform, or when the OpenSSL 3 runtime libraries

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -21,9 +21,7 @@ The runtime environment must provide:
 
 Confidential ACI publishes `host-amd-cert-base64` and
 `reference-info-base64` under its `UVM_SECURITY_CONTEXT_DIR`. Send those files
-and an SNP attestation report to the relying party. The example below uses a
-hex-encoded report, matching the
-[`caci-attestation-verify` demo](https://github.com/microsoft/TEE-Attestation-Verification/tree/main/demos/caci-attestation-verify).
+and a hex-encoded SNP attestation report to the relying party.
 
 ```csharp
 using System.Text.Json;
@@ -33,7 +31,6 @@ const string TrustedDidX509 =
     "did:x509:0:sha256:I__iuL25oXEVFdTP_aBLx_eT1RPHbCQ_ECBQfYZpt9s" +
     "::eku:1.3.6.1.4.1.311.76.59.1.2";
 const string TrustedUvmFeed = "ContainerPlat-AMD-UVM";
-const ulong MinimumUvmSvn = 104;
 
 // Evidence supplied by the C-ACI workload is untrusted until verified.
 byte[] reportBytes = ReadHexFile("attestation-report.hex");
@@ -43,10 +40,9 @@ byte[] uvmEndorsement = ReadBase64File("reference-info-base64");
 // Relying-party policy must be configured independently of that evidence.
 ReadOnlyMemory<byte>[] trustedPolicyDigests =
 [
-    Convert.FromHexString(
-        "4f4448c67f3c8dfc8de8a5e37125d807" +
-        "dadcc41f06cf23f615dbd52eec777d10"),
+    ReadHexFile("trusted-policy-digest.hex"),
 ];
+ulong minimumUvmSvn = ulong.Parse(File.ReadAllText("minimum-uvm-svn").Trim());
 
 using SnpAttestationReport report = AttestationVerifier.VerifySnpAttestation(
     reportBytes,
@@ -59,11 +55,11 @@ using CborValue uvm = AttestationVerifier.VerifyUvmEndorsement(
 
 byte[] reportData = AttestationVerifier.VerifyCaciAttestation(
     report,
-    [], // The minimum TCB policy is omitted from this example.
+    [],
     trustedPolicyDigests,
     uvm,
     TrustedUvmFeed,
-    MinimumUvmSvn);
+    minimumUvmSvn);
 
 Console.WriteLine(Convert.ToHexString(reportData));
 
@@ -105,9 +101,8 @@ sealed record AmdEndorsements(string ArkPem, string AskPem, string VcekPem);
 verified 64-byte report data. The trusted DID and UVM feed are the stable
 identifiers specified by the
 [Confidential ACI scheme](https://github.com/microsoft/confidential-aci-examples/blob/main/docs/Confidential_ACI_SCHEME.md#reference-info-base64).
-Replace the policy digest and minimum SVN above with independently managed
-relying-party configuration. Do not trust values merely because the workload
-supplied them.
+Load trusted policy digests and the minimum SVN from relying-party
+configuration.
 
 Native calls fail with `DllNotFoundException` when the package does not carry a
 native asset for the running platform, or when the OpenSSL 3 runtime libraries

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -98,8 +98,8 @@ sealed record AmdEndorsements(string ArkPem, string AskPem, string VcekPem);
 `VerifySnpAttestation` authenticates the AMD certificate chain and SNP report,
 `VerifyUvmEndorsement` authenticates `reference-info-base64`, and
 `VerifyCaciAttestation` applies the relying-party policy before returning the
-verified 64-byte report data. The trusted DID and UVM feed are the stable
-identifiers specified by the
+verified 64-byte report data. The trusted DID, UVM feed, and minimum SVN are
+specified by the
 [Confidential ACI scheme](https://github.com/microsoft/confidential-aci-examples/blob/main/docs/Confidential_ACI_SCHEME.md#reference-info-base64).
 Load trusted policy digests and the minimum SVN from relying-party
 configuration.

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -105,13 +105,9 @@ sealed record AmdEndorsements(string ArkPem, string AskPem, string VcekPem);
 verified 64-byte report data. The trusted DID and UVM feed are the stable
 identifiers specified by the
 [Confidential ACI scheme](https://github.com/microsoft/confidential-aci-examples/blob/main/docs/Confidential_ACI_SCHEME.md#reference-info-base64).
-The policy digest and minimum SVN above come from the checked-in
-[demo manifest](https://github.com/microsoft/TEE-Attestation-Verification/blob/main/demos/caci-attestation-verify/test-data/manifest.json).
-Replace the demo values with independently managed relying-party configuration,
-and follow C-ACI's
-[platform update guidance](https://github.com/microsoft/confidential-aci-examples/blob/main/docs/Confidential_ACI_SCHEME.md#platform-update-timing)
-when setting a production minimum SVN. Do not trust values merely because the
-workload supplied them.
+Replace the policy digest and minimum SVN above with independently managed
+relying-party configuration. Do not trust values merely because the workload
+supplied them.
 
 Native calls fail with `DllNotFoundException` when the package does not carry a
 native asset for the running platform, or when the OpenSSL 3 runtime libraries

--- a/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
+++ b/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>TeeAttestationVerification</AssemblyName>
     <RootNamespace>TeeAttestationVerification</RootNamespace>
     <PackageId>TeeAttestationVerification</PackageId>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft. All rights reserved.</Copyright>


### PR DESCRIPTION
Update the .NET README.md to match expected usage in production.

To get this to propagate to nuget we need to cut another release but that is fine.