### PR TITLE
Add an unverified SNP report constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-## [1.0.6]
+## [1.0.7]
 
-[1.0.6]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.6
+[1.0.7]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.7
 
 ### Added
 
 - C and .NET FFI constructors for decoding SNP reports without verification. (#101)
+
+## [1.0.6]
+
+[1.0.6]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.6
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [1.0.6]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.6
 
+### Added
+
+- C and .NET FFI constructors for decoding SNP reports without verification. (#101)
+
 ### Changed
 
 - Updated the NuGet package README to consume C-ACI's published endorsement formats directly. (#98)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-caci"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "serde_json",
  "tee-attestation-verification-cose",
@@ -1049,7 +1049,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-cose"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "cborrs",
  "cborrs-nondet",
@@ -1058,7 +1058,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-crypto"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "ecdsa",
  "foreign-types",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-ffi"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-lib"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "console_error_panic_hook",
  "curl",

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-lib"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -45,7 +45,7 @@ env_logger = "0.11"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 zerocopy = {version = "0.8.31", features = ["derive"]}
 
 # KDS (online certificate fetching) dependencies

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-caci"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -32,9 +32,9 @@ crypto_webcrypto = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.6", path = "../attestation", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.6", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 serde_json = "1"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-cose"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -16,7 +16,7 @@ crypto_pure_rust = ["crypto/crypto_pure_rust"]
 crypto_webcrypto = ["crypto/crypto_webcrypto"]
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 # project-everest/everparse tag v2026.07.02 resolves to this pinned commit.
 cborrs = { git = "https://github.com/project-everest/everparse.git", rev = "950bc93838ac2faae51126d8acd0637cf8c8a569" }
 cborrs-nondet = { git = "https://github.com/project-everest/everparse.git", rev = "950bc93838ac2faae51126d8acd0637cf8c8a569" }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-crypto"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-ffi"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -33,10 +33,10 @@ crypto_webcrypto = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.6", path = "../attestation", default-features = false }
-caci = { package = "tee-attestation-verification-caci", version = "1.0.6", path = "../caci", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.6", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.6", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
+caci = { package = "tee-attestation-verification-caci", version = "1.0.7", path = "../caci", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 serde_json = "1"
 zerocopy = { version = "0.8.31", features = ["derive"] }
 

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -17,6 +17,19 @@ The runtime environment must provide:
 - glibc 2.35 or newer;
 - OpenSSL 3 (`libssl.so.3` and `libcrypto.so.3`).
 
+## Inspect an unverified SNP report
+
+```csharp
+using SnpAttestationReport report =
+    SnpAttestationReport.FromUnverifiedBytes(reportBytes);
+byte[] chipId = report.ChipId();
+```
+
+`FromUnverifiedBytes` checks only that the input has the fixed SNP report size.
+Field values, reserved bytes, signatures, certificates, and TCBs remain
+untrusted. Use `VerifySnpAttestation` before making trust decisions, and do not
+pass an unverified report to `VerifyCaciAttestation`.
+
 ## Verify a CACI attestation
 
 Confidential ACI publishes `host-amd-cert-base64` and

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -8,7 +8,7 @@ repository's native C ABI.
 Add the package from your configured NuGet feed:
 
 ```bash
-dotnet add package TeeAttestationVerification --version 1.0.6
+dotnet add package TeeAttestationVerification --version 1.0.7
 ```
 
 The runtime environment must provide:

--- a/ffi/csharp/TeeAttestationVerification.Tests/PemAndSnpTests.cs
+++ b/ffi/csharp/TeeAttestationVerification.Tests/PemAndSnpTests.cs
@@ -120,6 +120,29 @@ public sealed class PemAndSnpTests
                 oversized.Value, input.Ark, input.Ask, input.Vcek));
     }
 
+    [Fact]
+    public void FromUnverifiedBytesExposesTamperedReportFields()
+    {
+        MilanInputs input = FixtureData.LoadMilan();
+        input.Report[0x90] ^= 0xff;
+
+        using SnpAttestationReport report =
+            SnpAttestationReport.FromUnverifiedBytes(input.Report);
+
+        Assert.Equal(3u, report.Version);
+        Assert.Equal(0xa0, report.Measurement()[0]);
+    }
+
+    [Fact]
+    public void FromUnverifiedBytesRejectsInvalidLength()
+    {
+        VerifyException error = Assert.Throws<VerifyException>(() =>
+            SnpAttestationReport.FromUnverifiedBytes(new byte[100]));
+
+        Assert.Equal(ErrorCode.InvalidArgument, error.Code);
+        Assert.Contains("expected 1184 bytes, got 100", error.Message);
+    }
+
     private static string Hex(byte[] bytes) => Convert.ToHexString(bytes).ToLowerInvariant();
 
     private sealed class OversizedMemoryManager : MemoryManager<byte>

--- a/ffi/csharp/TeeAttestationVerification/NativeMethods.cs
+++ b/ffi/csharp/TeeAttestationVerification/NativeMethods.cs
@@ -51,6 +51,12 @@ internal static partial class NativeMethods
         nuint vcekPemLength,
         out IntPtr report);
 
+    [LibraryImport(LibraryName, EntryPoint = "tav_snp_attestation_report_from_unverified_bytes")]
+    internal static partial IntPtr SnpReportFromUnverifiedBytes(
+        IntPtr reportBytes,
+        nuint reportLength,
+        out IntPtr report);
+
     [LibraryImport(LibraryName, EntryPoint = "tav_snp_attestation_report_version")]
     internal static partial uint SnpVersion(SafeSnpReportHandle report);
 

--- a/ffi/csharp/TeeAttestationVerification/SnpAttestationReport.cs
+++ b/ffi/csharp/TeeAttestationVerification/SnpAttestationReport.cs
@@ -3,8 +3,11 @@
 
 namespace TeeAttestationVerification;
 
-/// <summary>An owned, cryptographically verified AMD SEV-SNP attestation report.</summary>
-/// <remarks>Byte-array methods return new managed copies on each call.</remarks>
+/// <summary>An owned AMD SEV-SNP attestation report.</summary>
+/// <remarks>
+/// Byte-array methods return new managed copies on each call. Reports returned by
+/// <see cref="FromUnverifiedBytes"/> have not been cryptographically verified.
+/// </remarks>
 public sealed class SnpAttestationReport : IDisposable
 {
     private readonly object _sync = new();
@@ -14,10 +17,34 @@ public sealed class SnpAttestationReport : IDisposable
     {
         if (handle == IntPtr.Zero)
         {
-            throw new InvalidOperationException("Native verification returned a null report.");
+            throw new InvalidOperationException("Native operation returned a null report.");
         }
 
         _handle = new SafeSnpReportHandle(handle);
+    }
+
+    /// <summary>
+    /// Parses a report without cryptographically verifying its contents.
+    /// </summary>
+    /// <param name="reportBytes">The binary SNP attestation report.</param>
+    /// <returns>An owned fixed-size decoded but unverified report.</returns>
+    /// <exception cref="VerifyException">The input does not have the SNP report size.</exception>
+    public static SnpAttestationReport FromUnverifiedBytes(
+        ReadOnlyMemory<byte> reportBytes)
+    {
+        byte[] report = NativeInput.Snapshot(reportBytes, nameof(reportBytes));
+        unsafe
+        {
+            fixed (byte* reportPointer = report)
+            {
+                IntPtr error = NativeMethods.SnpReportFromUnverifiedBytes(
+                    (IntPtr)reportPointer,
+                    (nuint)report.Length,
+                    out IntPtr unverifiedReport);
+                NativeResult.ThrowIfError(error);
+                return new SnpAttestationReport(unverifiedReport);
+            }
+        }
     }
 
     /// <summary>Gets the report format version.</summary>
@@ -114,7 +141,7 @@ public sealed class SnpAttestationReport : IDisposable
     /// <summary>Returns a copy of the report signature S component.</summary>
     public byte[] SignatureS() => GetBytes(NativeMethods.SnpSignatureS);
 
-    /// <summary>Releases the verified native report.</summary>
+    /// <summary>Releases the native report.</summary>
     public void Dispose()
     {
         lock (_sync)

--- a/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
+++ b/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>TeeAttestationVerification</AssemblyName>
     <RootNamespace>TeeAttestationVerification</RootNamespace>
     <PackageId>TeeAttestationVerification</PackageId>
-    <Version>1.0.6</Version>
+    <Version>1.0.7</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft. All rights reserved.</Copyright>

--- a/ffi/include/tav/caci.h
+++ b/ffi/include/tav/caci.h
@@ -57,6 +57,10 @@ TAV_CACI_API TavError *tav_verify_caci_uvm_endorsement(
 /*
  * Verify the relying-party CACI policy over staged verified artifacts.
  *
+ * attestation must be a report returned by tav_verify_snp_attestation. The
+ * caller is responsible for not passing a report created by
+ * tav_snp_attestation_report_from_unverified_bytes.
+ *
  * The minimum TCB policy is passed as two parallel arrays of minimum_tcb_count
  * entries: minimum_tcb_cpuids holds one uint32_t CPUID per entry, and
  * minimum_tcb_values holds minimum_tcb_count contiguous 8-byte TCB values (the

--- a/ffi/include/tav/snp.h
+++ b/ffi/include/tav/snp.h
@@ -20,18 +20,19 @@ extern "C" {
  *
  * Usage summary:
  * - Call tav_verify_snp_attestation with the raw attestation report and the
- *   ARK, ASK, and VCEK certificates in PEM format.
- * - On success, verification writes a TavSnpAttestationReport* to out_report.
+ *   ARK, ASK, and VCEK certificates in PEM format, or call
+ *   tav_snp_attestation_report_from_unverified_bytes for fixed-size decoding
+ *   without authentication or semantic validation.
+ * - On success, either function writes a TavSnpAttestationReport* to out_report.
  *   Pass that report handle to the tav_snp_attestation_report_* accessors.
  * - Free the report handle with tav_snp_attestation_report_free when finished.
  *
  * Error behavior:
- * - tav_verify_snp_attestation returns NULL on success, or an owned TavError*
- *   on failure. Inspect failures with tav_error_code and tav_error_message,
- *   then free them with tav_error_free.
- * - tav_verify_snp_attestation reports invalid verification inputs and invalid
- *   out_report state as TavError failures. Each input buffer is capped at
- *   1 GiB.
+ * - Both report constructors return NULL on success, or an owned TavError* on
+ *   failure. Inspect failures with tav_error_code and tav_error_message, then
+ *   free them with tav_error_free.
+ * - Both constructors report invalid inputs and invalid out_report state as
+ *   TavError failures. Each input buffer is capped at 1 GiB.
  * - Error accessors are defensive for NULL TavError pointers: tav_error_code
  *   returns TAV_ERROR_IS_NULL and tav_error_message returns a static
  *   diagnostic string.
@@ -63,7 +64,22 @@ TAV_API TavError *tav_verify_snp_attestation(
     size_t vcek_pem_len,
     TavSnpAttestationReport **out_report);
 
-/* Scalar report accessors. Invalid report pointers are undefined behavior. */
+/*
+ * Parse an SNP attestation report without cryptographic verification.
+ *
+ * This checks only that the input has the fixed SNP report size. It does not
+ * validate field values, reserved bytes, signatures, certificates, or TCBs.
+ * Do not make trust decisions from the returned report.
+ *
+ * out_report must point to a writable report-handle slot. The slot is set to
+ * NULL before any fallible work and set to an owned handle only on success.
+ */
+TAV_API TavError *tav_snp_attestation_report_from_unverified_bytes(
+    const uint8_t *report_bytes,
+    size_t report_len,
+    TavSnpAttestationReport **out_report);
+
+/* Report accessors. Invalid report pointers are undefined behavior. */
 TAV_API uint32_t tav_snp_attestation_report_version(
     const TavSnpAttestationReport *report);
 TAV_API uint32_t tav_snp_attestation_report_guest_svn(
@@ -196,7 +212,7 @@ TAV_API void tav_snp_attestation_report_signature_s(
     const uint8_t **data,
     size_t *len);
 
-/* Frees a report handle returned by tav_verify_snp_attestation. NULL is a no-op. */
+/* Frees a report handle returned by either report constructor. NULL is a no-op. */
 TAV_API void tav_snp_attestation_report_free(TavSnpAttestationReport *report);
 
 #ifdef __cplusplus

--- a/ffi/src/c_ffi/README.md
+++ b/ffi/src/c_ffi/README.md
@@ -65,6 +65,19 @@ tav_snp_attestation_report_measurement(report, &measurement, &measurement_len);
 tav_snp_attestation_report_free(report);
 ```
 
+To inspect fields before certificates are available, parse without verification:
+
+```c
+TavSnpAttestationReport *unverified_report = NULL;
+TavError *error = tav_snp_attestation_report_from_unverified_bytes(
+    report_bytes, report_len, &unverified_report);
+```
+
+This checks only that the input has the fixed SNP report size. Field values,
+reserved bytes, signatures, certificates, and TCBs remain untrusted. Field
+accessors accept this handle. Callers must not pass it to APIs requiring
+authenticated evidence, including `tav_verify_caci_attestation`.
+
 ## CACI verification
 
 CACI verification is staged: verify the SNP attestation and the UVM

--- a/ffi/src/c_ffi/README.md
+++ b/ffi/src/c_ffi/README.md
@@ -65,19 +65,6 @@ tav_snp_attestation_report_measurement(report, &measurement, &measurement_len);
 tav_snp_attestation_report_free(report);
 ```
 
-To inspect fields before certificates are available, parse without verification:
-
-```c
-TavSnpAttestationReport *unverified_report = NULL;
-TavError *error = tav_snp_attestation_report_from_unverified_bytes(
-    report_bytes, report_len, &unverified_report);
-```
-
-This checks only that the input has the fixed SNP report size. Field values,
-reserved bytes, signatures, certificates, and TCBs remain untrusted. Field
-accessors accept this handle. Callers must not pass it to APIs requiring
-authenticated evidence, including `tav_verify_caci_attestation`.
-
 ## CACI verification
 
 CACI verification is staged: verify the SNP attestation and the UVM

--- a/ffi/src/c_ffi/snp.rs
+++ b/ffi/src/c_ffi/snp.rs
@@ -5,9 +5,12 @@
 //!
 //! This module exports the symbols declared in `ffi/include/tav/snp.h`.
 //!
-//! [`tav_verify_snp_attestation`] returns a null [`TavError`] pointer on
-//! success and an owned [`TavError`] pointer on failure. On success it
-//! writes an owned [`TavSnpAttestationReport`] handle to `out_report`.
+//! [`tav_verify_snp_attestation`] and
+//! [`tav_snp_attestation_report_from_unverified_bytes`] return a null
+//! [`TavError`] pointer on success and an owned [`TavError`] pointer on failure.
+//! On success they write an owned [`TavSnpAttestationReport`] handle to
+//! `out_report`. The latter performs fixed-size decoding only; its handle must
+//! not be used where a cryptographically verified report is required.
 //! Callers release these handles with [`crate::c_ffi::utils::tav_error_free`] and
 //! [`tav_snp_attestation_report_free`].
 //!
@@ -39,11 +42,20 @@ fn tav_error_from_verification_error(error: VerificationError) -> TavError {
     TavError::new(code, error.to_string())
 }
 
+fn parse_report(report_bytes: &[u8]) -> Result<&AttestationReport, TavError> {
+    AttestationReport::ref_from_bytes(report_bytes).map_err(|_| {
+        TavError::invalid_argument(format!(
+            "Invalid attestation report: expected {} bytes, got {}",
+            std::mem::size_of::<AttestationReport>(),
+            report_bytes.len()
+        ))
+    })
+}
+
 impl TavSnpAttestationReport {
     pub fn report(&self) -> &AttestationReport {
-        AttestationReport::ref_from_bytes(&self.bytes).expect(
-            "TavSnpAttestationReport is only constructed from verified bytes so parsing should not fail",
-        )
+        AttestationReport::ref_from_bytes(&self.bytes)
+            .expect("TavSnpAttestationReport is only constructed from exact-size bytes")
     }
 }
 
@@ -94,13 +106,7 @@ pub unsafe extern "C" fn tav_verify_snp_attestation(
 
         let report_bytes =
             unsafe { input_bytes(report_bytes, report_len, "attestation report", false) }?;
-        let report = AttestationReport::ref_from_bytes(report_bytes).map_err(|_| {
-            TavError::invalid_argument(format!(
-                "Invalid attestation report: expected {} bytes, got {}",
-                std::mem::size_of::<AttestationReport>(),
-                report_len
-            ))
-        })?;
+        let report = parse_report(report_bytes)?;
 
         let ark_pem = unsafe { input_bytes(ark_pem, ark_pem_len, "ARK", false) }?;
         let ark = certificate_from_pem(ark_pem).map_err(|error| {
@@ -126,6 +132,29 @@ pub unsafe extern "C" fn tav_verify_snp_attestation(
             },
         )
         .map_err(tav_error_from_verification_error)?;
+
+        let report = TavSnpAttestationReport {
+            bytes: report_bytes.to_vec(),
+        };
+        unsafe {
+            *out_report = Box::into_raw(Box::new(report));
+        }
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tav_snp_attestation_report_from_unverified_bytes(
+    report_bytes: *const u8,
+    report_len: usize,
+    out_report: *mut *mut TavSnpAttestationReport,
+) -> *mut TavError {
+    into_result(|| {
+        unsafe { owned_out_ptr(out_report, "out_report") }?;
+
+        let report_bytes =
+            unsafe { input_bytes(report_bytes, report_len, "attestation report", false) }?;
+        parse_report(report_bytes)?;
 
         let report = TavSnpAttestationReport {
             bytes: report_bytes.to_vec(),

--- a/ffi/tests/c-consumer/snp.cpp
+++ b/ffi/tests/c-consumer/snp.cpp
@@ -157,6 +157,60 @@ TEST_CASE("snp: a tampered report fails verification and leaves the handle null"
     tav_error_free(error);
 }
 
+TEST_CASE("snp: unverified bytes expose report fields without authenticating them") {
+    MilanInputs in = load_milan_inputs();
+    in.report.at(0x90) ^= 0xff;
+
+    TavSnpAttestationReport *report = nullptr;
+    TavError *error = tav_snp_attestation_report_from_unverified_bytes(
+        in.report.data(), in.report.size(), &report);
+
+    REQUIRE(error == nullptr);
+    REQUIRE(report != nullptr);
+    CHECK(hex_field(report, tav_snp_attestation_report_measurement).rfind("a0", 0) == 0);
+    tav_snp_attestation_report_free(report);
+}
+
+TEST_CASE("snp: invalid unverified report length leaves the handle null") {
+    MilanInputs in = load_milan_inputs();
+    in.report.pop_back();
+
+    TavSnpAttestationReport *report =
+        reinterpret_cast<TavSnpAttestationReport *>(0x1);
+    TavError *error = tav_snp_attestation_report_from_unverified_bytes(
+        in.report.data(), in.report.size(), &report);
+
+    REQUIRE(error != nullptr);
+    CHECK(tav_error_code(error) == TAV_ERROR_INVALID_ARGUMENT);
+    CHECK(std::string(tav_error_message(error)) ==
+          "Invalid attestation report: expected 1184 bytes, got 1183");
+    CHECK(report == nullptr);
+    tav_error_free(error);
+}
+
+TEST_CASE("snp: unverified report constructor validates pointers") {
+    MilanInputs in = load_milan_inputs();
+
+    TavSnpAttestationReport *report =
+        reinterpret_cast<TavSnpAttestationReport *>(0x1);
+    TavError *error = tav_snp_attestation_report_from_unverified_bytes(
+        nullptr, in.report.size(), &report);
+    REQUIRE(error != nullptr);
+    CHECK(tav_error_code(error) == TAV_ERROR_INVALID_ARGUMENT);
+    CHECK(std::string(tav_error_message(error)) ==
+          "attestation report pointer is null");
+    CHECK(report == nullptr);
+    tav_error_free(error);
+
+    error = tav_snp_attestation_report_from_unverified_bytes(
+        in.report.data(), in.report.size(), nullptr);
+    REQUIRE(error != nullptr);
+    CHECK(tav_error_code(error) == TAV_ERROR_INVALID_ARGUMENT);
+    CHECK(std::string(tav_error_message(error)) ==
+          "out_report pointer is null");
+    tav_error_free(error);
+}
+
 TEST_CASE("snp: oversized input is rejected before any dereference") {
     uint8_t dummy = 0;
     TavSnpAttestationReport *report = nullptr;


### PR DESCRIPTION
## Summary

- add `tav_snp_attestation_report_from_unverified_bytes` to decode fixed-size SNP reports without verification
- expose the constructor through the .NET binding as `SnpAttestationReport.FromUnverifiedBytes`
- reuse the existing report accessors and handle type, with explicit warnings that decoded fields are untrusted
- document that callers must use the verification constructor before trust decisions or staged CACI verification

## Testing

- Rust FFI tests with OpenSSL and pure-Rust backends
- C consumer tests with both backends and shared/static linking
- packaged .NET binding tests: 15 passed
- formatting, version-sync, license-header, and whitespace checks