### PR TITLE
Improved testing of extension apis

### DIFF
--- a/crypto/src/crypto_openssl.rs
+++ b/crypto/src/crypto_openssl.rs
@@ -8,8 +8,8 @@
 //! verification. It is the native backend selected when `crypto_openssl` is
 //! enabled for a non-`wasm32` target.
 
-use foreign_types::{ForeignType, ForeignTypeRef};
-use openssl::asn1::{Asn1Object, Asn1ObjectRef, Asn1Time};
+use foreign_types::ForeignType;
+use openssl::asn1::{Asn1Object, Asn1Time};
 use openssl::bn::BigNum;
 use openssl::ecdsa::EcdsaSig;
 use openssl::hash::{hash, MessageDigest};
@@ -21,7 +21,7 @@ use openssl::stack::Stack;
 use openssl::x509::verify::X509VerifyFlags;
 use openssl::x509::verify::X509VerifyParam;
 use openssl_sys::{
-    ASN1_STRING_get0_data, ASN1_STRING_length, X509_EXTENSION_get_critical,
+    ASN1_STRING_get0_data, ASN1_STRING_length, OBJ_obj2txt, X509_EXTENSION_get_critical,
     X509_EXTENSION_get_data, X509_EXTENSION_get_object, X509_get_ext, X509_get_ext_by_OBJ,
     X509_get_ext_count, X509_get_extension_flags, X509_get_key_usage, X509v3_KU_KEY_CERT_SIGN,
     EXFLAG_CA,
@@ -281,10 +281,31 @@ impl CertificateBackend for Crypto {
                     return None;
                 }
 
-                Some(unsafe { Asn1ObjectRef::from_ptr(object) }.to_string())
+                dotted_decimal_oid(object)
             })
             .collect()
     }
+}
+
+/// `Asn1Object`'s display form is the long name for known OIDs, so ask OpenSSL
+/// for the numeric form that `CertificateBackend` specifies.
+fn dotted_decimal_oid(object: *mut openssl_sys::ASN1_OBJECT) -> Option<String> {
+    let mut buffer = [0u8; 128];
+    let written = unsafe {
+        OBJ_obj2txt(
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as i32,
+            object,
+            1, // no_name: always emit the dotted-decimal form.
+        )
+    };
+    if written <= 0 || written as usize >= buffer.len() {
+        return None;
+    }
+
+    std::str::from_utf8(&buffer[..written as usize])
+        .ok()
+        .map(str::to_owned)
 }
 
 mod oid {

--- a/crypto/src/tests.rs
+++ b/crypto/src/tests.rs
@@ -276,6 +276,18 @@ fn extension_lookup_rejects_malformed_oid() {
     Crypto::get_extension_value_by_oid(&cert, "not-an-oid").expect_err("Malformed OID should fail");
 }
 
+#[test]
+fn critical_extension_oids_list_the_critical_extensions() {
+    let oids = Crypto::critical_extension_oids(&cert(MILAN_ASK));
+
+    assert!(oids.iter().any(|oid| oid == "2.5.29.19"));
+    assert!(oids
+        .iter()
+        .all(|oid| Crypto::extension_criticality(&cert(MILAN_ASK), oid)
+            .expect("Criticality should decode")
+            == Some(true)));
+}
+
 #[cfg(sync_crypto)]
 mod sync_tests {
     use super::*;

--- a/crypto/src/tests.rs
+++ b/crypto/src/tests.rs
@@ -277,6 +277,36 @@ fn extension_lookup_rejects_malformed_oid() {
 }
 
 #[test]
+fn basic_constraints_decode_from_a_certificate_authority() {
+    let constraints = Crypto::basic_constraints(&cert(MILAN_ASK))
+        .expect("Basic constraints should decode")
+        .expect("ASK should have basic constraints");
+
+    assert!(constraints.critical);
+    assert!(constraints.ca);
+    assert_eq!(constraints.path_len_constraint, Some(0));
+
+    assert_eq!(
+        Crypto::basic_constraints(&cert(MILAN_VCEK)).expect("Basic constraints should decode"),
+        None
+    );
+}
+
+#[test]
+fn key_usage_decodes_certificate_signing() {
+    let usage = Crypto::key_usage(&cert(MILAN_ASK))
+        .expect("Key usage should decode")
+        .expect("ASK should have key usage");
+
+    assert!(usage.key_cert_sign);
+
+    assert_eq!(
+        Crypto::key_usage(&cert(MILAN_VCEK)).expect("Key usage should decode"),
+        None
+    );
+}
+
+#[test]
 fn critical_extension_oids_list_the_critical_extensions() {
     let oids = Crypto::critical_extension_oids(&cert(MILAN_ASK));
 


### PR DESCRIPTION
There was a deviation between openssl and other backends, the critical extension oids were expanded in openssl and were kept in dotted form in the other backends.

This adds tests to pin that behaviour as well as other ones.