### PR TITLE
Ignore Cargo lockfile-only Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    exclude-paths:
+      - "Cargo.lock"
     cooldown:
       default-days: 5
     groups:

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -46,7 +46,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
-zerocopy = {version = "0.8.31", features = ["derive"]}
+zerocopy = { version = "0.8", features = ["derive"] }
 
 # KDS (online certificate fetching) dependencies
 log = { version = "0.4" }

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -38,7 +38,7 @@ caci = { package = "tee-attestation-verification-caci", version = "1.0.7", path 
 cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 serde_json = "1"
-zerocopy = { version = "0.8.31", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["derive"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3"


### PR DESCRIPTION
Dependabot treats any github repo with a cargo.lock as an application and hence enforces bumps across the entire transitive dependency chain.

Our constraints are:
- Dependencies are must be captured to make releases reproducible
- Dependabot bumps every cargo.lock dependency all the time

The two ways to resolve this is to:
- Remove cargo.lock and generate it at release time and test against that
  - requires us to thread the cargo.lock through the CI etc and in practise rework the entire CI
- Tell dependabot to ignore cargo.lock