### PR TITLE
Add cross-platform native libraries to the C# NuGet package

### DIFF
--- a/.github/workflows/ci-ffi.yml
+++ b/.github/workflows/ci-ffi.yml
@@ -102,24 +102,5 @@ jobs:
         run: ctest --test-dir target/c-consumer-tests --output-on-failure
 
   ffi-csharp-api:
-    name: FFI C# API consumer tests (Linux x64)
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install rust
-        run: |
-          rustup update stable && rustup default stable
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
-        with:
-          dotnet-version: "8.0.423"
-
-      - name: Install OpenSSL build dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libssl-dev pkg-config
-
-      - name: Run C# native API consumer tests
-        shell: bash
-        run: python3 ffi/csharp/run_tests.py --configuration Release
+    name: FFI C# API consumer tests
+    uses: ./.github/workflows/csharp-package.yml

--- a/.github/workflows/csharp-package.yml
+++ b/.github/workflows/csharp-package.yml
@@ -1,0 +1,132 @@
+name: C# native package
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build-native:
+    name: Build native library (${{ matrix.rid }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: linux-x64
+            runner: ubuntu-22.04
+            feature: crypto_openssl
+            library: libtee_attestation_verification_ffi.so
+          - rid: osx-x64
+            runner: macos-15-intel
+            feature: crypto_openssl
+            library: libtee_attestation_verification_ffi.dylib
+          - rid: win-x64
+            runner: windows-2022
+            feature: crypto_windows
+            library: tee_attestation_verification_ffi.dll
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Rust
+        shell: bash
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: Configure OpenSSL
+        if: runner.os == 'macOS'
+        shell: bash
+        run: echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> "${GITHUB_ENV}"
+
+      - name: Build native library
+        shell: bash
+        run: >
+          cargo build --locked --release --manifest-path ffi/Cargo.toml
+          --no-default-features --features "${{ matrix.feature }}"
+
+      - name: Stage native library
+        shell: bash
+        run: |
+          mkdir -p native-asset
+          cp "target/release/${{ matrix.library }}" native-asset/
+
+      - name: Upload native library
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: csharp-native-${{ matrix.rid }}
+          path: native-asset/${{ matrix.library }}
+
+  pack:
+    name: Pack C# NuGet
+    runs-on: ubuntu-22.04
+    needs: build-native
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: "8.0.423"
+
+      - name: Download native libraries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: csharp-native-*
+          path: native-assets
+
+      - name: Pack C# NuGet
+        shell: bash
+        run: >
+          dotnet pack
+          ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
+          --configuration Release
+          --output package
+          -p:TavNativeAssetsRoot="${GITHUB_WORKSPACE}/native-assets"
+
+      - name: Upload C# NuGet
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: csharp-nuget-package
+          path: package/*.nupkg
+
+  test-package:
+    name: Test C# NuGet (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    needs: pack
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64
+            runner: ubuntu-22.04
+          - name: macOS x64
+            runner: macos-15-intel
+          - name: Windows x64
+            runner: windows-2022
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: "8.0.423"
+
+      - name: Download C# NuGet
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: csharp-nuget-package
+          path: package
+
+      - name: Run C# native API consumer tests
+        shell: bash
+        run: python ffi/csharp/run_tests.py --configuration Release --package package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,9 @@ jobs:
   package:
     name: Package release artifacts
     runs-on: ubuntu-22.04
-    needs: prepare_release
+    needs:
+      - prepare_release
+      - ci-ffi
     env:
       VERSION: ${{ needs.prepare_release.outputs.version }}
     steps:
@@ -128,9 +130,6 @@ jobs:
         with:
           dotnet-version: "8.0.423"
 
-      - name: Install OpenSSL build dependencies
-        run: sudo apt-get update && sudo apt-get install --yes libssl-dev pkg-config
-
       - name: Build tav-wasm bundle with WebCrypto crypto
         shell: bash
         working-directory: ffi
@@ -148,15 +147,11 @@ jobs:
 
           tar -C ../dist -czf "../release-artifacts/tav-wasm-${VERSION}.tar.gz" tav-wasm
 
-      - name: Build and pack .NET package and native library
-        shell: bash
-        run: |
-          set -euo pipefail
-          dotnet pack \
-            ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj \
-            --configuration Release \
-            -p:PackageVersion="${VERSION}" \
-            --output release-artifacts
+      - name: Download tested C# NuGet
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: csharp-nuget-package
+          path: release-artifacts
 
       - name: Capture build toolchain info
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - C and .NET FFI constructors for decoding SNP reports without verification. (#101)
 - Windows CNG crypto provider. (#100)
+- Windows and macOS x64 native libraries in the .NET NuGet package.
 
 ## [1.0.6]
 

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -1,7 +1,7 @@
 # TeeAttestationVerification for .NET
 
-Linux x64 .NET 8 bindings for verifying SNP and CACI attestations through the
-repository's native C ABI.
+Cross-platform x64 .NET 8 bindings for verifying SNP and CACI attestations
+through the repository's native C ABI.
 
 ## Install
 
@@ -11,11 +11,14 @@ Add the package from your configured NuGet feed:
 dotnet add package TeeAttestationVerification --version 1.0.7
 ```
 
-The runtime environment must provide:
+Supported runtime identifiers:
 
-- a Linux x64 process;
-- glibc 2.35 or newer;
-- OpenSSL 3 (`libssl.so.3` and `libcrypto.so.3`).
+- `linux-x64` with glibc 2.35 or newer and OpenSSL 3;
+- `osx-x64` with OpenSSL 3;
+- `win-x64` on Windows 10 or Windows Server 2016 and newer.
+
+ARM platforms are not currently supported. OpenSSL must be installed separately
+on Linux and macOS; on macOS, it is available from Homebrew as `openssl@3`.
 
 ## Inspect an unverified SNP report
 
@@ -118,8 +121,8 @@ Load trusted policy digests and the minimum SVN from relying-party
 configuration.
 
 Native calls fail with `DllNotFoundException` when the package does not carry a
-native asset for the running platform, or when the OpenSSL 3 runtime libraries
-are missing.
+native asset for the running platform, or when required OpenSSL 3 runtime
+libraries are missing.
 
 ## Ownership and errors
 
@@ -138,15 +141,14 @@ Run from `ffi/csharp`:
 python3 run_tests.py --configuration Release
 ```
 
-The runner packs a uniquely versioned NuGet into a temporary feed, restores the
-public xUnit consumer suite against that exact package, and tests the complete
-NuGet → C# → C ABI → Rust path. It also checks the package layout and OpenSSL
-dependencies.
+The runner packs a uniquely versioned Linux development NuGet into a temporary
+feed, restores the public xUnit consumer suite against that exact package, and
+tests the complete NuGet → C# → C ABI → Rust path.
 
 Source builds require Rust, the OpenSSL development headers, and `pkg-config`.
 The MSBuild project invokes Cargo with `crypto_openssl` for every build.
 
-To create a release package:
+To create a local Linux development package:
 
 ```bash
 dotnet pack \
@@ -154,5 +156,7 @@ dotnet pack \
   --configuration Release
 ```
 
-The native asset is packaged at
+The local native asset is packaged at
 `runtimes/linux-x64/native/libtee_attestation_verification_ffi.so`.
+Release packages are built in CI from native assets produced on all three host
+operating systems.

--- a/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
+++ b/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
@@ -12,7 +12,7 @@
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft. All rights reserved.</Copyright>
-    <Description>Linux x64 .NET bindings for TEE attestation verification.</Description>
+    <Description>Cross-platform x64 .NET bindings for TEE attestation verification.</Description>
     <PackageTags>TEE;Attestation;SEV-SNP;Confidential-Computing;Microsoft</PackageTags>
     <PackageProjectUrl>https://github.com/microsoft/TEE-Attestation-Verification</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -24,11 +24,12 @@
     <TavNativeProfile Condition="'$(TavNativeProfile)' == ''">debug</TavNativeProfile>
     <TavCargoProfileFlag Condition="'$(Configuration)' == 'Release'">--release</TavCargoProfileFlag>
     <TavNativeLibrary>$(TavRepoRoot)target/$(TavNativeProfile)/libtee_attestation_verification_ffi.so</TavNativeLibrary>
+    <TavNativeAssetsRootNormalized Condition="'$(TavNativeAssetsRoot)' != ''">$([MSBuild]::EnsureTrailingSlash($([System.IO.Path]::GetFullPath('$(TavNativeAssetsRoot)'))))</TavNativeAssetsRootNormalized>
     <TavHostRid Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</TavHostRid>
     <TavHostRid Condition="'$(TavHostRid)' == ''">$(NETCoreSdkRuntimeIdentifier)</TavHostRid>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TavNativeAssetsRoot)' == ''">
     <None Include="$(TavNativeLibrary)"
           Link="libtee_attestation_verification_ffi.so"
           CopyToOutputDirectory="PreserveNewest"
@@ -39,7 +40,25 @@
     <None Include="../README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
-  <Target Name="ValidateNativePlatform" BeforeTargets="BuildNativeLibrary">
+  <ItemGroup Condition="'$(TavNativeAssetsRoot)' != ''">
+    <None Include="$(TavNativeAssetsRootNormalized)csharp-native-linux-x64/libtee_attestation_verification_ffi.so"
+          Pack="true"
+          PackagePath="runtimes/linux-x64/native/"
+          Visible="false" />
+    <None Include="$(TavNativeAssetsRootNormalized)csharp-native-osx-x64/libtee_attestation_verification_ffi.dylib"
+          Pack="true"
+          PackagePath="runtimes/osx-x64/native/"
+          Visible="false" />
+    <None Include="$(TavNativeAssetsRootNormalized)csharp-native-win-x64/tee_attestation_verification_ffi.dll"
+          Pack="true"
+          PackagePath="runtimes/win-x64/native/"
+          Visible="false" />
+    <None Include="../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+  <Target Name="ValidateNativePlatform"
+          BeforeTargets="BuildNativeLibrary"
+          Condition="'$(TavNativeAssetsRoot)' == ''">
     <Error Condition="!$([MSBuild]::IsOSPlatform('Linux'))"
            Text="TeeAttestationVerification currently supports Linux only." />
     <Error Condition="'$(TavHostRid)' != 'linux-x64'"
@@ -48,7 +67,7 @@
 
   <Target Name="BuildNativeLibrary"
           BeforeTargets="PrepareForBuild"
-          Condition="'$(DesignTimeBuild)' != 'true'">
+          Condition="'$(DesignTimeBuild)' != 'true' and '$(TavNativeAssetsRoot)' == ''">
     <Exec WorkingDirectory="$(TavRepoRoot)"
           Command="cargo build --locked --manifest-path &quot;$(TavRepoRoot)ffi/Cargo.toml&quot; --no-default-features --features crypto_openssl $(TavCargoProfileFlag)" />
   </Target>

--- a/ffi/csharp/run_tests.py
+++ b/ffi/csharp/run_tests.py
@@ -11,10 +11,9 @@ that package, and run the tests without rebuilding the binding from source.
 from __future__ import annotations
 
 import argparse
-import fcntl
 import os
 import pathlib
-import re
+import shutil
 import subprocess
 import tempfile
 import uuid
@@ -32,21 +31,15 @@ TEST_PROJECT = (
     / "TeeAttestationVerification.Tests"
     / "TeeAttestationVerification.Tests.csproj"
 )
-NATIVE_ASSET = (
-    "runtimes/linux-x64/native/libtee_attestation_verification_ffi.so"
-)
-EXPECTED_NATIVE_DEPENDENCIES = frozenset(
+NATIVE_ASSETS = frozenset(
     {
-        "ld-linux-x86-64.so.2",
-        "libc.so.6",
-        "libcrypto.so.3",
-        "libgcc_s.so.1",
-        "libssl.so.3",
+        "runtimes/linux-x64/native/libtee_attestation_verification_ffi.so",
+        "runtimes/osx-x64/native/libtee_attestation_verification_ffi.dylib",
+        "runtimes/win-x64/native/tee_attestation_verification_ffi.dll",
     }
 )
-LOCK_FILE = (
-    pathlib.Path(tempfile.gettempdir())
-    / "tee-attestation-verification-csharp-tests.lock"
+LOCAL_NATIVE_ASSETS = frozenset(
+    {"runtimes/linux-x64/native/libtee_attestation_verification_ffi.so"}
 )
 
 
@@ -63,7 +56,22 @@ def test_package_version() -> str:
     return f"{version}-test.{uuid.uuid4().hex[:12]}"
 
 
-def verify_package(package: pathlib.Path, native_library: pathlib.Path) -> None:
+def package_version(package: pathlib.Path) -> str:
+    with zipfile.ZipFile(package) as archive:
+        nuspecs = [name for name in archive.namelist() if name.endswith(".nuspec")]
+        if len(nuspecs) != 1:
+            raise RuntimeError(f"Expected one nuspec in {package}, found {nuspecs}")
+        root = ElementTree.fromstring(archive.read(nuspecs[0]))
+
+    for element in root.iter():
+        if element.tag.rsplit("}", 1)[-1] == "version" and element.text:
+            return element.text
+    raise RuntimeError(f"{package} nuspec does not define a version")
+
+
+def verify_package(
+    package: pathlib.Path, expected_native_assets: frozenset[str]
+) -> None:
     with zipfile.ZipFile(package) as archive:
         entries = set(archive.namelist())
         expected_managed = "lib/net8.0/TeeAttestationVerification.dll"
@@ -72,34 +80,62 @@ def verify_package(package: pathlib.Path, native_library: pathlib.Path) -> None:
             raise RuntimeError(f"{package} does not contain {expected_managed}")
         if expected_documentation not in entries:
             raise RuntimeError(f"{package} does not contain {expected_documentation}")
-        if NATIVE_ASSET not in entries:
-            raise RuntimeError(f"{package} does not contain {NATIVE_ASSET}")
+        native_assets = frozenset(
+            entry
+            for entry in entries
+            if entry.startswith("runtimes/") and "/native/" in entry
+        )
+        if native_assets != expected_native_assets:
+            raise RuntimeError(
+                f"{package} native assets differ: expected "
+                f"{sorted(expected_native_assets)}, found {sorted(native_assets)}"
+            )
         if any(
             "libssl" in entry.lower() or "libcrypto" in entry.lower()
             for entry in entries
         ):
             raise RuntimeError("OpenSSL libraries must not be bundled in the package")
-        native_library.write_bytes(archive.read(NATIVE_ASSET))
 
-    dynamic_section = subprocess.run(
-        ["readelf", "--dynamic", "--wide", str(native_library)],
-        check=True,
-        capture_output=True,
-        env={**os.environ, "LC_ALL": "C"},
-        text=True,
-    ).stdout
-    dependencies = frozenset(
-        re.findall(r"\(NEEDED\).*Shared library: \[([^]]+)]", dynamic_section)
+
+def find_package(path: pathlib.Path) -> pathlib.Path:
+    if path.is_file():
+        return path
+    packages = list(path.glob("TeeAttestationVerification.*.nupkg"))
+    if len(packages) != 1:
+        raise RuntimeError(f"Expected one package in {path}, found {len(packages)}")
+    return packages[0]
+
+
+def write_nuget_config(path: pathlib.Path, feed: pathlib.Path) -> None:
+    configuration = ElementTree.Element("configuration")
+    sources = ElementTree.SubElement(configuration, "packageSources")
+    ElementTree.SubElement(sources, "clear")
+    ElementTree.SubElement(
+        sources, "add", key="test-feed", value=str(feed)
     )
-    if dependencies != EXPECTED_NATIVE_DEPENDENCIES:
-        raise RuntimeError(
-            f"{NATIVE_ASSET} dependencies differ: expected "
-            f"{sorted(EXPECTED_NATIVE_DEPENDENCIES)}, found {sorted(dependencies)}"
-        )
+    ElementTree.SubElement(
+        sources,
+        "add",
+        key="nuget.org",
+        value="https://api.nuget.org/v3/index.json",
+    )
+    mappings = ElementTree.SubElement(configuration, "packageSourceMapping")
+    local_mapping = ElementTree.SubElement(
+        mappings, "packageSource", key="test-feed"
+    )
+    ElementTree.SubElement(
+        local_mapping, "package", pattern="TeeAttestationVerification"
+    )
+    public_mapping = ElementTree.SubElement(
+        mappings, "packageSource", key="nuget.org"
+    )
+    ElementTree.SubElement(public_mapping, "package", pattern="*")
+    ElementTree.ElementTree(configuration).write(
+        path, encoding="utf-8", xml_declaration=True
+    )
 
 
-def run_tests(configuration: str) -> None:
-    version = test_package_version()
+def run_tests(configuration: str, supplied_package: pathlib.Path | None) -> None:
     with tempfile.TemporaryDirectory(prefix="tav-csharp-tests-") as temporary:
         temp = pathlib.Path(temporary)
         feed = temp / "feed"
@@ -107,28 +143,33 @@ def run_tests(configuration: str) -> None:
         env = os.environ.copy()
         env["NUGET_PACKAGES"] = str(temp / "packages")
 
-        run(
-            [
-                "dotnet",
-                "pack",
-                str(PACKAGE_PROJECT),
-                "--configuration",
-                configuration,
-                "--output",
-                str(feed),
-                f"-p:PackageVersion={version}",
-            ],
-            env=env,
-        )
+        if supplied_package is None:
+            version = test_package_version()
+            run(
+                [
+                    "dotnet",
+                    "pack",
+                    str(PACKAGE_PROJECT),
+                    "--configuration",
+                    configuration,
+                    "--output",
+                    str(feed),
+                    f"-p:PackageVersion={version}",
+                ],
+                env=env,
+            )
+            package = find_package(feed)
+            expected_native_assets = LOCAL_NATIVE_ASSETS
+        else:
+            package = find_package(supplied_package.resolve())
+            shutil.copy2(package, feed)
+            package = feed / package.name
+            version = package_version(package)
+            expected_native_assets = NATIVE_ASSETS
 
-        packages = list(feed.glob("TeeAttestationVerification.*.nupkg"))
-        if len(packages) != 1:
-            raise RuntimeError(f"Expected one package, found {len(packages)}")
-        package = packages[0]
-        expected_name = f"TeeAttestationVerification.{version}.nupkg"
-        if package.name != expected_name:
-            raise RuntimeError(f"Expected {expected_name}, got {package.name}")
-        verify_package(package, temp / "libtee_attestation_verification_ffi.so")
+        verify_package(package, expected_native_assets)
+        nuget_config = temp / "NuGet.Config"
+        write_nuget_config(nuget_config, feed)
 
         common_properties = [
             f"-p:TavPackageVersion={version}",
@@ -138,10 +179,8 @@ def run_tests(configuration: str) -> None:
                 "dotnet",
                 "restore",
                 str(TEST_PROJECT),
-                "--source",
-                str(feed),
-                "--source",
-                "https://api.nuget.org/v3/index.json",
+                "--configfile",
+                str(nuget_config),
                 *common_properties,
             ],
             env=env,
@@ -165,11 +204,14 @@ def main() -> int:
         description="Pack TeeAttestationVerification and run its public consumer tests"
     )
     parser.add_argument("--configuration", default="Release")
+    parser.add_argument(
+        "--package",
+        type=pathlib.Path,
+        help="Existing package file or directory to test without rebuilding",
+    )
     args = parser.parse_args()
 
-    with LOCK_FILE.open("w") as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
-        run_tests(args.configuration)
+    run_tests(args.configuration, args.package)
 
     return 0
 


### PR DESCRIPTION
Packages Linux, macOS, and Windows x64 native libraries in one C# NuGet package.

A reusable workflow builds each native library on its host OS, assembles the package once, and runs the same public C# consumer suite against that exact package on all three hosts. Tagged releases publish the tested package unchanged, while local `dotnet pack` remains a Linux-only development flow.

ARM64 and native binary signing remain out of scope. Linux and macOS dynamically link against host-provided OpenSSL 3.

Manual testing: `python3 ffi/csharp/run_tests.py --configuration Release`; staged three-RID package assembly and artifact-only consumption on Linux.