### PR TITLE
Make dependencies not fixed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
         patterns:
           - "getrandom"
           - "rand"
+      # OpenSSL pointer traits must match the versions used by its bindings.
+      openssl:
+        patterns:
+          - "foreign-types-shared"
+          - "openssl"
+          - "openssl-sys"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,13 @@ updates:
     cooldown:
       default-days: 5
     groups:
-      rustcrypto:
+      # The curve crates exchange RustCrypto key and signature types.
+      elliptic-curves:
         patterns:
           - "ecdsa"
           - "p256"
           - "p384"
           - "p521"
-          - "sha2"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
           - "pkcs1"
           - "rsa"
           - "x509-cert"
+      # rand's OS-backed generators and getrandom's WASM support move together.
+      random:
+        patterns:
+          - "getrandom"
+          - "rand"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,12 @@ updates:
           - "p256"
           - "p384"
           - "p521"
+      # X.509 signature parsing exchanges DER, OID, and PKCS#1 types.
+      rsa-x509:
+        patterns:
+          - "pkcs1"
+          - "rsa"
+          - "x509-cert"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "cmov"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,14 +489,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "r-efi",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -643,7 +655,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -910,14 +922,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -935,9 +963,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
 
 [[package]]
 name = "rand_core"
@@ -1240,7 +1265,7 @@ dependencies = [
  "p384",
  "p521",
  "pkcs1 0.8.0-rc.4",
- "rand",
+ "rand 0.10.2",
  "rsa",
  "sha2 0.10.9",
  "sha2 0.11.0",
@@ -1366,12 +1391,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,47 +1518,46 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -1586,42 +1585,36 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -1639,7 +1632,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1660,11 +1653,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "der_derive",
- "flagset",
- "pem-rfc7468",
  "zeroize",
 ]
 
@@ -305,14 +302,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid 0.10.2",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
  "zeroize",
 ]
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -804,6 +804,16 @@ dependencies = [
  "der 0.7.10",
  "pkcs8 0.10.2",
  "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -985,7 +995,7 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
+ "pkcs1 0.7.5",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "signature 2.2.0",
@@ -1167,6 +1177,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
+ "base64ct",
  "der 0.8.1",
 ]
 
@@ -1228,7 +1239,7 @@ dependencies = [
  "p256",
  "p384",
  "p521",
- "pkcs1",
+ "pkcs1 0.8.0-rc.4",
  "rand",
  "rsa",
  "sha2 0.10.9",
@@ -1698,13 +1709,13 @@ dependencies = [
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "105ef4642d9cb137ef83d623d0e4bf08b8adf69e9918ca904a174adb6d3d038b"
 dependencies = [
- "const-oid 0.9.6",
- "der 0.7.10",
- "spki 0.7.3",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "spki 0.8.0",
  "tls_codec",
 ]
 

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -46,7 +46,7 @@ env_logger = ">=0.11, <0.12"
 tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = ">=1.0.7, <2", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
 zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 
 # KDS (online certificate fetching) dependencies

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -39,28 +39,28 @@ path = "src/bin/verify_cli.rs"
 required-features = ["kds"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-env_logger = "0.11"
+wasm-bindgen-test = ">=0.3, <0.4"
+env_logger = ">=0.11, <0.12"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
-zerocopy = { version = "0.8", features = ["derive"] }
+crypto = { package = "tee-attestation-verification-crypto", version = ">=1.0.7, <2", path = "../crypto", default-features = false }
+zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 
 # KDS (online certificate fetching) dependencies
-log = { version = "0.4" }
+log = { version = ">=0.4, <0.5" }
 
 # Native deps
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true}
-curl = { version = "0.4", optional = true }
+tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"], optional = true}
+curl = { version = ">=0.4, <0.5", optional = true }
 
 # WASM deps
 [target.'cfg(target_family = "wasm")'.dependencies]
-console_error_panic_hook = { version = "0.1", optional = true }
-js-sys = { version = "0.3", optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
-wasm-bindgen-futures = { version = "0.4", optional = true }
-wasm-logger = { version = "0.2", optional = true }
+console_error_panic_hook = { version = ">=0.1, <0.2", optional = true }
+js-sys = { version = ">=0.3, <0.4", optional = true }
+wasm-bindgen = { version = ">=0.2, <0.3", optional = true }
+wasm-bindgen-futures = { version = ">=0.4, <0.5", optional = true }
+wasm-logger = { version = ">=0.2, <0.3", optional = true }

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -46,7 +46,7 @@ env_logger = ">=0.11, <0.12"
 tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 
 # KDS (online certificate fetching) dependencies

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -37,9 +37,9 @@ crypto_windows = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "=1.0.7", path = "../attestation", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "=1.0.7", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 serde_json = ">=1, <2"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -37,9 +37,9 @@ crypto_windows = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "=1.0.7", path = "../attestation", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "=1.0.7", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
 serde_json = ">=1, <2"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -40,10 +40,10 @@ crypto_windows = [
 attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
 cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
-serde_json = "1"
+serde_json = ">=1, <2"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = ">=0.3, <0.4"

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -17,5 +17,5 @@ crypto_webcrypto = ["crypto/crypto_webcrypto"]
 crypto_windows = ["crypto/crypto_windows"]
 
 [dependencies]
-cbor = { package = "tee-attestation-verification-cbor", version = "=1.0.7", path = "../cbor" }
-crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
+cbor = { package = "tee-attestation-verification-cbor", version = "1.0.7", path = "../cbor" }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -17,5 +17,5 @@ crypto_webcrypto = ["crypto/crypto_webcrypto"]
 crypto_windows = ["crypto/crypto_windows"]
 
 [dependencies]
-cbor = { package = "tee-attestation-verification-cbor", version = "1.0.7", path = "../cbor" }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+cbor = { package = "tee-attestation-verification-cbor", version = "=1.0.7", path = "../cbor" }
+crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -28,38 +28,38 @@ crypto_webcrypto = ["dep:pkcs1", "dep:x509-cert"]
 crypto_windows = ["dep:windows"]
 
 [dependencies]
-foreign-types-shared = { version = "0.1", optional = true }
-ecdsa = { version = "0.17", features = ["der"], default-features = false, optional = true }
-p256 = { version = "0.14", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
-p384 = { version = "0.14", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
-p521 = { version = "0.14", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
-pkcs1 = { version = "0.7", optional = true }
-rsa = { version = "0.9", default-features = false, optional = true }
-sha2 = { version = "0.11", features = ["oid"], optional = true }
-sha2_10 = { package = "sha2", version = "0.10", features = ["oid"], optional = true }
-x509-cert = { version = "0.2", optional = true }
+foreign-types-shared = { version = ">=0.1, <0.2", optional = true }
+ecdsa = { version = ">=0.17, <0.18", features = ["der"], default-features = false, optional = true }
+p256 = { version = ">=0.14, <0.15", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
+p384 = { version = ">=0.14, <0.15", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
+p521 = { version = ">=0.14, <0.15", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
+pkcs1 = { version = ">=0.7, <0.8", optional = true }
+rsa = { version = ">=0.9, <0.10", default-features = false, optional = true }
+sha2 = { version = ">=0.11, <0.12", features = ["oid"], optional = true }
+sha2_10 = { package = "sha2", version = ">=0.10, <0.11", features = ["oid"], optional = true }
+x509-cert = { version = ">=0.2, <0.3", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-openssl = { version = "0.10", optional = true }
-openssl-sys = { version = "0.9", optional = true }
+openssl = { version = ">=0.10, <0.11", optional = true }
+openssl-sys = { version = ">=0.9, <0.10", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # 0.61 supports the workspace MSRV while exposing the required Crypt32 and CNG APIs.
-windows = { version = "0.61.3", optional = true, features = [
+windows = { version = ">=0.61.3, <0.62", optional = true, features = [
     "Win32_Foundation",
     "Win32_Security_Cryptography",
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-js-sys = "0.3"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+js-sys = ">=0.3, <0.4"
+wasm-bindgen = ">=0.2, <0.3"
+wasm-bindgen-futures = ">=0.4, <0.5"
 
 [dev-dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-rand = "0.8"
-sha2 = { version = "0.11", features = ["oid"] }
-wasm-bindgen-test = "0.3"
+getrandom = { version = ">=0.2, <0.3", features = ["js"] }
+rand = ">=0.8, <0.9"
+sha2 = { version = ">=0.11, <0.12", features = ["oid"] }
+wasm-bindgen-test = ">=0.3, <0.4"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -44,8 +44,8 @@ openssl = { version = ">=0.10, <0.11", optional = true }
 openssl-sys = { version = ">=0.9, <0.10", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-# 0.61 supports the workspace MSRV while exposing the required Crypt32 and CNG APIs.
-windows = { version = ">=0.61.3, <0.62", optional = true, features = [
+# 0.62 supports the workspace MSRV while exposing the required Crypt32 and CNG APIs.
+windows = { version = ">=0.62.2, <0.63", optional = true, features = [
     "Win32_Foundation",
     "Win32_Security_Cryptography",
 ] }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -56,8 +56,8 @@ wasm-bindgen = ">=0.2, <0.3"
 wasm-bindgen-futures = ">=0.4, <0.5"
 
 [dev-dependencies]
-getrandom = { version = ">=0.2, <0.3", features = ["js"] }
-rand = ">=0.8, <0.9"
+getrandom = { version = ">=0.4, <0.5", features = ["wasm_js"] }
+rand = ">=0.10.0, <0.11"
 sha2 = { version = ">=0.11, <0.12", features = ["oid"] }
 wasm-bindgen-test = ">=0.3, <0.4"
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -33,11 +33,11 @@ ecdsa = { version = ">=0.17, <0.18", features = ["der"], default-features = fals
 p256 = { version = ">=0.14, <0.15", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
 p384 = { version = ">=0.14, <0.15", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
 p521 = { version = ">=0.14, <0.15", features = ["ecdsa", "pkcs8"], default-features = false, optional = true }
-pkcs1 = { version = ">=0.7, <0.8", optional = true }
+pkcs1 = { version = ">=0.8.0-rc.4, <0.9", optional = true }
 rsa = { version = ">=0.9, <0.10", default-features = false, optional = true }
 sha2 = { version = ">=0.11, <0.12", features = ["oid"], optional = true }
 sha2_10 = { package = "sha2", version = ">=0.10, <0.11", features = ["oid"], optional = true }
-x509-cert = { version = ">=0.2, <0.3", optional = true }
+x509-cert = { version = ">=0.3.0, <0.4", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 openssl = { version = ">=0.10, <0.11", optional = true }

--- a/crypto/src/crypto_windows.rs
+++ b/crypto/src/crypto_windows.rs
@@ -94,7 +94,7 @@ impl NativeCertificate {
             unsafe { Crypto32::CertCreateCertificateContext(Crypto32::X509_ASN_ENCODING, der) };
         NonNull::new(context)
             .map(Self)
-            .ok_or_else(|| windows::core::Error::from_win32().into())
+            .ok_or_else(|| windows::core::Error::from_thread().into())
     }
 
     fn as_ptr(&self) -> *const Crypto32::CERT_CONTEXT {
@@ -292,7 +292,7 @@ impl CertificateBackend for Crypto {
             let output = output.map(|output| PSTR(output.as_mut_ptr()));
             if !unsafe { Crypto32::CryptBinaryToStringA(cert.der(), flags, output, len) }.as_bool()
             {
-                return Err(windows::core::Error::from_win32().into());
+                return Err(windows::core::Error::from_thread().into());
             }
             Ok(())
         })?;
@@ -686,7 +686,7 @@ fn name(value: &Crypto32::CRYPT_INTEGER_BLOB) -> Result<String> {
             )
         };
         if *len == 0 {
-            Err(windows::core::Error::from_win32().into())
+            Err(windows::core::Error::from_thread().into())
         } else {
             Ok(())
         }

--- a/crypto/src/tests.rs
+++ b/crypto/src/tests.rs
@@ -466,16 +466,18 @@ mod async_tests {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     async fn digest_matches_rustcrypto_on_random_data() {
-        use rand::{rngs::OsRng, rngs::StdRng, Rng, RngCore, SeedableRng};
+        use rand::{rngs::StdRng, rngs::SysRng, Rng, RngExt, SeedableRng, TryRng};
         use sha2::{Digest, Sha256, Sha384, Sha512};
 
-        let seed = OsRng.next_u64();
+        let seed = SysRng
+            .try_next_u64()
+            .expect("system RNG should provide a test seed");
         eprintln!("digest random seed: {seed:#018x}");
         let mut random = StdRng::seed_from_u64(seed);
 
         for _ in 0..1024 {
-            let max_len = 1usize << random.gen_range(0..=13);
-            let mut data = vec![0; random.gen_range(0..=max_len)];
+            let max_len = 1usize << random.random_range(0..=13);
+            let mut data = vec![0; random.random_range(0..=max_len)];
             random.fill_bytes(&mut data);
 
             assert_eq!(

--- a/crypto/src/x509_certificate.rs
+++ b/crypto/src/x509_certificate.rs
@@ -8,6 +8,10 @@ use x509_cert::der::{
 };
 use x509_cert::ext::pkix::{BasicConstraints as X509BasicConstraints, KeyUsage as X509KeyUsage};
 use x509_cert::spki::AlgorithmIdentifierOwned;
+use x509_cert::{
+    certificate::{CertificateInner, Profile},
+    time::Time,
+};
 
 use super::{
     BasicConstraints, KeyUsage, Result, RsaPkcs1v15SignatureKeyAlgorithm,
@@ -16,19 +20,28 @@ use super::{
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Certificate {
-    inner: x509_cert::Certificate,
+    inner: CertificateInner<PreserveTimeEncoding>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+struct PreserveTimeEncoding;
+
+impl Profile for PreserveTimeEncoding {
+    fn time_encoding(time: Time) -> x509_cert::der::Result<Time> {
+        Ok(time)
+    }
 }
 
 impl Certificate {
     // Certificate accessors.
     pub fn from_pem(pem: &[u8]) -> Result<Self> {
         Ok(Self {
-            inner: x509_cert::Certificate::from_pem(pem)?,
+            inner: CertificateInner::from_pem(pem)?,
         })
     }
 
     pub fn from_pem_chain(pem: &[u8]) -> Result<Vec<Self>> {
-        x509_cert::Certificate::load_pem_chain(pem)?
+        CertificateInner::load_pem_chain(pem)?
             .into_iter()
             .map(|inner| Ok(Self { inner }))
             .collect()
@@ -36,7 +49,7 @@ impl Certificate {
 
     pub fn from_der(der: &[u8]) -> Result<Self> {
         Ok(Self {
-            inner: x509_cert::Certificate::from_der(der)?,
+            inner: CertificateInner::from_der(der)?,
         })
     }
 
@@ -51,15 +64,15 @@ impl Certificate {
     pub fn public_key_spki_der(&self) -> Result<Vec<u8>> {
         Ok(self
             .inner
-            .tbs_certificate
-            .subject_public_key_info
+            .tbs_certificate()
+            .subject_public_key_info()
             .to_der()?)
     }
 
     pub fn get_extension_value_by_oid(&self, oid: &str) -> Result<Option<Vec<u8>>> {
         let oid = ObjectIdentifier::new(oid)?;
 
-        let extensions = match self.inner.tbs_certificate.extensions.as_ref() {
+        let extensions = match self.inner.tbs_certificate().extensions() {
             Some(extensions) => extensions,
             None => return Ok(None),
         };
@@ -71,47 +84,47 @@ impl Certificate {
     }
 
     pub fn tbs_certificate_der(&self) -> Result<Vec<u8>> {
-        Ok(self.inner.tbs_certificate.to_der()?)
+        Ok(self.inner.tbs_certificate().to_der()?)
     }
 
     pub fn signature_bytes(&self) -> &[u8] {
-        self.inner.signature.raw_bytes()
+        self.inner.signature().raw_bytes()
     }
 
     pub fn signature_algorithm(&self) -> Result<SignatureKeyAlgorithm> {
-        parse_signature_algorithm(&self.inner.signature_algorithm)
+        parse_signature_algorithm(self.inner.signature_algorithm())
     }
     pub fn subject_name(&self) -> String {
-        self.inner.tbs_certificate.subject.to_string()
+        self.inner.tbs_certificate().subject().to_string()
     }
 
     pub fn issuer_name(&self) -> String {
-        self.inner.tbs_certificate.issuer.to_string()
+        self.inner.tbs_certificate().issuer().to_string()
     }
 
     pub fn subject_name_der(&self) -> Result<Vec<u8>> {
-        Ok(self.inner.tbs_certificate.subject.to_der()?)
+        Ok(self.inner.tbs_certificate().subject().to_der()?)
     }
 
     pub fn issuer_name_der(&self) -> Result<Vec<u8>> {
-        Ok(self.inner.tbs_certificate.issuer.to_der()?)
+        Ok(self.inner.tbs_certificate().issuer().to_der()?)
     }
 
     pub fn is_valid_at(&self, unix_time: std::time::Duration) -> Result<bool> {
-        let validity = self.inner.tbs_certificate.validity;
+        let validity = self.inner.tbs_certificate().validity();
         Ok(validity.not_before.to_unix_duration() <= unix_time
             && unix_time <= validity.not_after.to_unix_duration())
     }
 
     pub fn version(&self) -> u8 {
-        self.inner.tbs_certificate.version as u8
+        self.inner.tbs_certificate().version() as u8
     }
 
     pub fn basic_constraints(&self) -> Result<Option<BasicConstraints>> {
         Ok(self
             .inner
-            .tbs_certificate
-            .get::<X509BasicConstraints>()?
+            .tbs_certificate()
+            .get_extension::<X509BasicConstraints>()?
             .map(|(critical, basic_constraints)| BasicConstraints {
                 critical,
                 ca: basic_constraints.ca,
@@ -122,8 +135,8 @@ impl Certificate {
     pub fn key_usage(&self) -> Result<Option<KeyUsage>> {
         Ok(self
             .inner
-            .tbs_certificate
-            .get::<X509KeyUsage>()?
+            .tbs_certificate()
+            .get_extension::<X509KeyUsage>()?
             .map(|(_, key_usage)| KeyUsage {
                 key_cert_sign: key_usage.key_cert_sign(),
             }))
@@ -134,9 +147,9 @@ impl Certificate {
 
         Ok(self
             .inner
-            .tbs_certificate
-            .extensions
-            .as_deref()
+            .tbs_certificate()
+            .extensions()
+            .map(Vec::as_slice)
             .unwrap_or(&[])
             .iter()
             .find(|extension| extension.extn_id == oid)
@@ -145,9 +158,9 @@ impl Certificate {
 
     pub fn critical_extension_oids(&self) -> Vec<String> {
         self.inner
-            .tbs_certificate
-            .extensions
-            .as_deref()
+            .tbs_certificate()
+            .extensions()
+            .map(Vec::as_slice)
             .unwrap_or(&[])
             .iter()
             .filter_map(|extension| extension.critical.then(|| extension.extn_id.to_string()))
@@ -276,9 +289,14 @@ mod oid {
 
 #[cfg(test)]
 mod test {
-    use x509_cert::der::{asn1::AnyRef, Decode, Encode};
+    use x509_cert::certificate::{Profile, Rfc5280};
+    use x509_cert::der::{
+        asn1::{AnyRef, GeneralizedTime},
+        DateTime, Decode, Encode,
+    };
+    use x509_cert::time::Time;
 
-    use super::Certificate;
+    use super::{Certificate, PreserveTimeEncoding};
     use crate::{
         RsaPkcs1v15SignatureKeyAlgorithm, RsaPssSignatureKeyAlgorithm, SignatureKeyAlgorithm,
     };
@@ -289,6 +307,22 @@ mod test {
 
     fn cert(pem: &[u8]) -> Certificate {
         Certificate::from_pem(pem).unwrap()
+    }
+
+    #[test]
+    fn certificate_profile_preserves_pre_2050_generalized_time() {
+        let time = Time::GeneralTime(GeneralizedTime::from_date_time(
+            DateTime::new(2026, 8, 17, 0, 0, 0).expect("test date should be valid"),
+        ));
+
+        assert!(matches!(
+            PreserveTimeEncoding::time_encoding(time).expect("time encoding should be preserved"),
+            Time::GeneralTime(_)
+        ));
+        assert!(matches!(
+            Rfc5280::time_encoding(time).expect("RFC 5280 time encoding should succeed"),
+            Time::UtcTime(_)
+        ));
     }
 
     #[test]
@@ -308,8 +342,8 @@ mod test {
             cert.public_key_spki_der()
                 .expect("SPKI extraction should succeed"),
             cert.inner
-                .tbs_certificate
-                .subject_public_key_info
+                .tbs_certificate()
+                .subject_public_key_info()
                 .to_der()
                 .expect("SPKI DER should encode")
         );

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -39,10 +39,10 @@ crypto_windows = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
-caci = { package = "tee-attestation-verification-caci", version = "1.0.7", path = "../caci", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "=1.0.7", path = "../attestation", default-features = false }
+caci = { package = "tee-attestation-verification-caci", version = "=1.0.7", path = "../caci", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "=1.0.7", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
 serde_json = ">=1, <2"
 zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -39,10 +39,10 @@ crypto_windows = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "=1.0.7", path = "../attestation", default-features = false }
-caci = { package = "tee-attestation-verification-caci", version = "=1.0.7", path = "../caci", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "=1.0.7", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "=1.0.7", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
+caci = { package = "tee-attestation-verification-caci", version = "1.0.7", path = "../caci", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
 serde_json = ">=1, <2"
 zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -43,10 +43,10 @@ attestation = { package = "tee-attestation-verification-lib", version = "1.0.7",
 caci = { package = "tee-attestation-verification-caci", version = "1.0.7", path = "../caci", default-features = false }
 cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
 crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
-serde_json = "1"
-zerocopy = { version = "0.8", features = ["derive"] }
+serde_json = ">=1, <2"
+zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-js-sys = "0.3"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+js-sys = ">=0.3, <0.4"
+wasm-bindgen = ">=0.2, <0.3"
+wasm-bindgen-futures = ">=0.4, <0.5"


### PR DESCRIPTION
This moves us from explicitly pinned dependencies to specifying ranges for the dependencies we are not relying on specific versions for. This should make dependabot happier.