### PR TITLE
Fixup changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## Unreleased
+## [1.0.8]
+
+[1.0.8]: https://github.com/microsoft/TEE-Attestation-Verification/releases/tag/tav-1.0.8
 
 ### Removed
 
-- Removed the `crypto_pure_rust` backend and feature from all crates.
+- Removed the `crypto_pure_rust` backend and feature from all crates. (#131)
 
 ## [1.0.7]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-caci"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "serde_json",
  "tee-attestation-verification-cose",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-cbor"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "cborrs",
  "cborrs-nondet",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-cose"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "tee-attestation-verification-cbor",
  "tee-attestation-verification-crypto",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-crypto"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "foreign-types-shared",
  "getrandom",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-ffi"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "js-sys",
  "serde_json",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation-verification-lib"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "console_error_panic_hook",
  "curl",

--- a/attestation/Cargo.toml
+++ b/attestation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-lib"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 rust-version = "1.85"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -45,7 +45,7 @@ env_logger = ">=0.11, <0.12"
 tokio = { version = ">=1, <2", features = ["rt-multi-thread", "macros"] }
 
 [dependencies]
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.8", path = "../crypto", default-features = false }
 zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 
 # KDS (online certificate fetching) dependencies

--- a/attestation/src/snp/report.rs
+++ b/attestation/src/snp/report.rs
@@ -702,36 +702,6 @@ mod tests {
         }
 
         #[test]
-        fn nonzero_r_scalar_padding_fails() {
-            let vcek = cert(MILAN_VCEK);
-            let mut report = report();
-
-            report.signature.r[48] = 1;
-
-            let err = verify_report_signature(&vcek, &report)
-                .expect_err("Nonzero r scalar padding should not verify");
-            assert!(
-                err.to_string().contains("Invalid r scalar padding"),
-                "expected r scalar padding error, got: {err}"
-            );
-        }
-
-        #[test]
-        fn nonzero_s_scalar_padding_fails() {
-            let vcek = cert(MILAN_VCEK);
-            let mut report = report();
-
-            report.signature.s[48] = 1;
-
-            let err = verify_report_signature(&vcek, &report)
-                .expect_err("Nonzero s scalar padding should not verify");
-            assert!(
-                err.to_string().contains("Invalid s scalar padding"),
-                "expected s scalar padding error, got: {err}"
-            );
-        }
-
-        #[test]
         fn wrong_cert_rejects_signature() {
             verify_report_signature(&cert(GENOA_VCEK), &report())
                 .expect_err("Wrong cert should not verify report");

--- a/caci/Cargo.toml
+++ b/caci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-caci"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 rust-version = "1.85"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -32,9 +32,9 @@ crypto_windows = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.8", path = "../attestation", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.8", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.8", path = "../crypto", default-features = false }
 serde_json = ">=1, <2"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]

--- a/cbor/Cargo.toml
+++ b/cbor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-cbor"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 rust-version = "1.77"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"

--- a/cose/Cargo.toml
+++ b/cose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-cose"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 rust-version = "1.85"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -16,5 +16,5 @@ crypto_webcrypto = ["crypto/crypto_webcrypto"]
 crypto_windows = ["crypto/crypto_windows"]
 
 [dependencies]
-cbor = { package = "tee-attestation-verification-cbor", version = "1.0.7", path = "../cbor" }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+cbor = { package = "tee-attestation-verification-cbor", version = "1.0.8", path = "../cbor" }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.8", path = "../crypto", default-features = false }

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-crypto"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 rust-version = "1.85"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tee-attestation-verification-ffi"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 rust-version = "1.85"
 repository = "https://github.com/microsoft/TEE-Attestation-Verification"
@@ -33,10 +33,10 @@ crypto_windows = [
 ]
 
 [dependencies]
-attestation = { package = "tee-attestation-verification-lib", version = "1.0.7", path = "../attestation", default-features = false }
-caci = { package = "tee-attestation-verification-caci", version = "1.0.7", path = "../caci", default-features = false }
-cose = { package = "tee-attestation-verification-cose", version = "1.0.7", path = "../cose", default-features = false }
-crypto = { package = "tee-attestation-verification-crypto", version = "1.0.7", path = "../crypto", default-features = false }
+attestation = { package = "tee-attestation-verification-lib", version = "1.0.8", path = "../attestation", default-features = false }
+caci = { package = "tee-attestation-verification-caci", version = "1.0.8", path = "../caci", default-features = false }
+cose = { package = "tee-attestation-verification-cose", version = "1.0.8", path = "../cose", default-features = false }
+crypto = { package = "tee-attestation-verification-crypto", version = "1.0.8", path = "../crypto", default-features = false }
 serde_json = ">=1, <2"
 zerocopy = { version = ">=0.8, <0.9", features = ["derive"] }
 

--- a/ffi/csharp/README.md
+++ b/ffi/csharp/README.md
@@ -8,7 +8,7 @@ through the repository's native C ABI.
 Add the package from your configured NuGet feed:
 
 ```bash
-dotnet add package TeeAttestationVerification --version 1.0.7
+dotnet add package TeeAttestationVerification --version 1.0.8
 ```
 
 Supported runtime identifiers:

--- a/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
+++ b/ffi/csharp/TeeAttestationVerification/TeeAttestationVerification.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>TeeAttestationVerification</AssemblyName>
     <RootNamespace>TeeAttestationVerification</RootNamespace>
     <PackageId>TeeAttestationVerification</PackageId>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft. All rights reserved.</Copyright>


### PR DESCRIPTION
Remove the obsolete pure-Rust-only report tests instead of broadening them to other backends, and synchronize Rust and .NET package versions with the 1.0.8 changelog entry.

Also some cleanup from #131 that didn't make it in.