### PR TITLE
Make CBOR navigation handles independently owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- Handle-based CBOR C ABI in the `tee-attestation-verification-ffi` crate, for building, parsing, serializing and inspecting CBOR, with a C++ wrapper in `ffi/include/tav/cbor.hpp`. (#128)
+- Handle-based CBOR C ABI in the `tee-attestation-verification-ffi` crate, with independently owned navigation handles and a C++ wrapper for building, parsing, serializing and inspecting CBOR. (#133)
 
 ### Removed
 

--- a/ffi/include/tav/cbor.hpp
+++ b/ffi/include/tav/cbor.hpp
@@ -7,19 +7,17 @@
 // in <tav/internal/cbor_abi.h> is internal to this header.
 //
 // Handle ownership:
-// - Value owns a CBOR value and every child below it, and releases it on
-//   destruction. Value cannot be copied, so one value is never named twice
-//   and cannot be consumed twice.
+// - Every Value is independently owned and releases its handle on destruction.
+//   Navigation returns another Value that keeps the same immutable document
+//   alive. Value cannot be copied, so one handle is never consumed twice.
 // - Container builders consume the values passed to them, leaving each source
 //   empty(). A consumed Value must not be used again.
-// - Ref borrows, and stays valid only while the owning Value lives. Only a
-//   named Value can be borrowed: ref() is rejected on a temporary.
 //
 // Payload ownership:
 // - Scalars are copied. Byte and text payloads are borrowed: a buffer passed
 //   to make_bytes, make_string, or a parse call must outlive every Value and
-//   Ref derived from it, and must not be modified meanwhile. Spans and views
-//   returned by as_bytes and as_string point into that same buffer.
+//   every Value derived from it, and must not be modified meanwhile. Spans and
+//   views returned by as_bytes and as_string point into that same buffer.
 //
 // Failures throw CborError: DecodeError from parsing and from reads that do
 // not match the value, EncodeError from construction and serialization.
@@ -124,7 +122,6 @@ inline SimpleValue boolean_to_simple(bool value)
     return value ? SimpleValue::True : SimpleValue::False;
 }
 
-class Ref;
 class Value;
 using MapItem = std::pair<Value, Value>;
 
@@ -135,118 +132,10 @@ Value make_string(std::string_view data);
 Value make_array(std::vector<Value>&& items);
 Value make_map(std::vector<MapItem>&& entries);
 Value make_tagged(uint64_t tag, Value&& payload);
-Value shallow_copy(const Ref& ref);
-Value deep_copy(const Ref& ref);
+Value shallow_copy(const Value& value);
+Value deep_copy(const Value& value);
 Value nondet_parse(std::span<const uint8_t> raw, size_t max_depth);
 Value det_parse(std::span<const uint8_t> raw, size_t max_depth);
-
-/// A borrowed value, valid until the owning Value is destroyed.
-class Ref
-{
-public:
-    explicit Ref(const TavCborHandle* handle) : handle_(handle) {}
-
-    [[nodiscard]] Kind kind() const
-    {
-        return static_cast<Kind>(tav_cbor_kind(handle_));
-    }
-
-    [[nodiscard]] int64_t as_signed() const
-    {
-        int64_t out = 0;
-        check(tav_cbor_as_signed(handle_, &out), "as_signed");
-        return out;
-    }
-
-    [[nodiscard]] uint8_t as_simple() const
-    {
-        uint8_t out = 0;
-        check(tav_cbor_as_simple(handle_, &out), "as_simple");
-        return out;
-    }
-
-    /// Borrows the buffer the value was built from or parsed out of.
-    [[nodiscard]] std::span<const uint8_t> as_bytes() const
-    {
-        const uint8_t* data = nullptr;
-        size_t len = 0;
-        check(tav_cbor_as_bytes(handle_, &data, &len), "as_bytes");
-        return {data, len};
-    }
-
-    /// Borrows the buffer the value was built from or parsed out of.
-    [[nodiscard]] std::string_view as_string() const
-    {
-        const char* data = nullptr;
-        size_t len = 0;
-        check(tav_cbor_as_string(handle_, &data, &len), "as_string");
-        return {data, len};
-    }
-
-    [[nodiscard]] uint64_t as_tag() const
-    {
-        uint64_t out = 0;
-        check(tav_cbor_as_tag(handle_, &out), "as_tag");
-        return out;
-    }
-
-    /// Array or map entry count.
-    [[nodiscard]] size_t size() const
-    {
-        size_t out = 0;
-        check(tav_cbor_size(handle_, &out), "size");
-        return out;
-    }
-
-    [[nodiscard]] Ref array_at(size_t index) const
-    {
-        const TavCborHandle* out = nullptr;
-        check(tav_cbor_array_at(handle_, index, &out), "array_at");
-        return Ref(out);
-    }
-
-    [[nodiscard]] Ref map_at(const Ref& key) const
-    {
-        const TavCborHandle* out = nullptr;
-        check(tav_cbor_map_at(handle_, key.handle_, &out), "map_at");
-        return Ref(out);
-    }
-
-    [[nodiscard]] Ref tag_at(uint64_t tag) const
-    {
-        const TavCborHandle* out = nullptr;
-        check(tav_cbor_tag_at(handle_, tag, &out), "tag_at");
-        return Ref(out);
-    }
-
-    [[nodiscard]] Ref map_key_at(size_t index) const
-    {
-        const TavCborHandle* out = nullptr;
-        check(tav_cbor_map_key_at(handle_, index, &out), "map_key_at");
-        return Ref(out);
-    }
-
-    [[nodiscard]] Ref map_value_at(size_t index) const
-    {
-        const TavCborHandle* out = nullptr;
-        check(tav_cbor_map_value_at(handle_, index, &out), "map_value_at");
-        return Ref(out);
-    }
-
-private:
-    friend Value shallow_copy(const Ref& ref);
-    friend Value deep_copy(const Ref& ref);
-
-    static void check(int status, const char* what)
-    {
-        if (status != TAV_CBOR_OK)
-        {
-            throw DecodeError(static_cast<Error>(status), what);
-        }
-    }
-
-    const TavCborHandle* handle_;
-};
 
 /// An owning value. Moving transfers the handle and empties the source.
 class Value
@@ -279,14 +168,96 @@ public:
         return handle_ == nullptr;
     }
 
-    /// Only an lvalue can be borrowed: a temporary would free the handle at
-    /// the end of the full expression, leaving the Ref pointing at nothing.
-    [[nodiscard]] Ref ref() const&
+    [[nodiscard]] Kind kind() const
     {
-        return Ref(handle_);
+        return static_cast<Kind>(tav_cbor_kind(handle_));
     }
 
-    Ref ref() const&& = delete;
+    [[nodiscard]] int64_t as_signed() const
+    {
+        int64_t out = 0;
+        check(tav_cbor_as_signed(handle_, &out), "as_signed");
+        return out;
+    }
+
+    [[nodiscard]] uint8_t as_simple() const
+    {
+        uint8_t out = 0;
+        check(tav_cbor_as_simple(handle_, &out), "as_simple");
+        return out;
+    }
+
+    /// Borrows the buffer the value was built from or parsed out of.
+    [[nodiscard]] std::span<const uint8_t> as_bytes() const&
+    {
+        const uint8_t* data = nullptr;
+        size_t len = 0;
+        check(tav_cbor_as_bytes(handle_, &data, &len), "as_bytes");
+        return {data, len};
+    }
+
+    std::span<const uint8_t> as_bytes() const&& = delete;
+
+    /// Borrows the buffer the value was built from or parsed out of.
+    [[nodiscard]] std::string_view as_string() const&
+    {
+        const char* data = nullptr;
+        size_t len = 0;
+        check(tav_cbor_as_string(handle_, &data, &len), "as_string");
+        return {data, len};
+    }
+
+    std::string_view as_string() const&& = delete;
+
+    [[nodiscard]] uint64_t as_tag() const
+    {
+        uint64_t out = 0;
+        check(tav_cbor_as_tag(handle_, &out), "as_tag");
+        return out;
+    }
+
+    /// Array or map entry count.
+    [[nodiscard]] size_t size() const
+    {
+        size_t out = 0;
+        check(tav_cbor_size(handle_, &out), "size");
+        return out;
+    }
+
+    [[nodiscard]] Value array_at(size_t index) const
+    {
+        TavCborHandle* out = nullptr;
+        check(tav_cbor_array_at(handle_, index, &out), "array_at");
+        return adopt(out, "array_at");
+    }
+
+    [[nodiscard]] Value map_at(const Value& key) const
+    {
+        TavCborHandle* out = nullptr;
+        check(tav_cbor_map_at(handle_, key.handle_, &out), "map_at");
+        return adopt(out, "map_at");
+    }
+
+    [[nodiscard]] Value tag_at(uint64_t tag) const
+    {
+        TavCborHandle* out = nullptr;
+        check(tav_cbor_tag_at(handle_, tag, &out), "tag_at");
+        return adopt(out, "tag_at");
+    }
+
+    [[nodiscard]] Value map_key_at(size_t index) const
+    {
+        TavCborHandle* out = nullptr;
+        check(tav_cbor_map_key_at(handle_, index, &out), "map_key_at");
+        return adopt(out, "map_key_at");
+    }
+
+    [[nodiscard]] Value map_value_at(size_t index) const
+    {
+        TavCborHandle* out = nullptr;
+        check(tav_cbor_map_value_at(handle_, index, &out), "map_value_at");
+        return adopt(out, "map_value_at");
+    }
 
     [[nodiscard]] std::vector<uint8_t> nondet_serialize(
       size_t max_depth = MAX_DEPTH) const
@@ -310,8 +281,8 @@ private:
     friend Value make_array(std::vector<Value>&&);
     friend Value make_map(std::vector<MapItem>&&);
     friend Value make_tagged(uint64_t, Value&&);
-    friend Value shallow_copy(const Ref&);
-    friend Value deep_copy(const Ref&);
+    friend Value shallow_copy(const Value&);
+    friend Value deep_copy(const Value&);
     friend Value nondet_parse(std::span<const uint8_t>, size_t);
     friend Value det_parse(std::span<const uint8_t>, size_t);
 
@@ -411,6 +382,14 @@ private:
             throw EncodeError(Error::ENCODE_FAILED, what);
         }
         return Value(handle);
+    }
+
+    static void check(int status, const char* what)
+    {
+        if (status != TAV_CBOR_OK)
+        {
+            throw DecodeError(static_cast<Error>(status), what);
+        }
     }
 
     using Encoder =
@@ -533,15 +512,15 @@ inline Value det_parse(std::span<const uint8_t> raw, size_t max_depth = MAX_DEPT
 /// again from the same buffer, so that buffer must outlive the result; a
 /// payload the source owns is copied. The source value itself need not
 /// outlive the result.
-inline Value shallow_copy(const Ref& ref)
+inline Value shallow_copy(const Value& value)
 {
-    return Value::adopt(tav_cbor_shallow_copy(ref.handle_), "shallow_copy");
+    return Value::adopt(tav_cbor_shallow_copy(value.handle_), "shallow_copy");
 }
 
 /// Copy a value, copying every payload, so the result borrows nothing.
-inline Value deep_copy(const Ref& ref)
+inline Value deep_copy(const Value& value)
 {
-    return Value::adopt(tav_cbor_deep_copy(ref.handle_), "deep_copy");
+    return Value::adopt(tav_cbor_deep_copy(value.handle_), "deep_copy");
 }
 
 /// Run f, prefixing msg onto any DecodeError it raises.

--- a/ffi/include/tav/cbor.hpp
+++ b/ffi/include/tav/cbor.hpp
@@ -515,6 +515,9 @@ inline Value shallow_copy(const Value& value)
 }
 
 /// Copy a value, copying every payload, so the result borrows nothing.
+///
+/// Do not keep a view obtained from a temporary result:
+/// `auto text = deep_copy(value).as_string();` leaves `text` dangling.
 inline Value deep_copy(const Value& value)
 {
     return Value::adopt(tav_cbor_deep_copy(value.handle_), "deep_copy");

--- a/ffi/include/tav/cbor.hpp
+++ b/ffi/include/tav/cbor.hpp
@@ -17,7 +17,8 @@
 // - Scalars are copied. Byte and text payloads are borrowed: a buffer passed
 //   to make_bytes, make_string, or a parse call must outlive every Value and
 //   every Value derived from it, and must not be modified meanwhile. Spans and
-//   views returned by as_bytes and as_string point into that same buffer.
+//   views returned by as_bytes and as_string must not outlive their payload
+//   storage.
 //
 // Failures throw CborError: DecodeError from parsing and from reads that do
 // not match the value, EncodeError from construction and serialization.
@@ -187,8 +188,8 @@ public:
         return out;
     }
 
-    /// Borrows the buffer the value was built from or parsed out of.
-    [[nodiscard]] std::span<const uint8_t> as_bytes() const&
+    /// Returns a non-owning view of the payload.
+    [[nodiscard]] std::span<const uint8_t> as_bytes() const
     {
         const uint8_t* data = nullptr;
         size_t len = 0;
@@ -196,18 +197,14 @@ public:
         return {data, len};
     }
 
-    std::span<const uint8_t> as_bytes() const&& = delete;
-
-    /// Borrows the buffer the value was built from or parsed out of.
-    [[nodiscard]] std::string_view as_string() const&
+    /// Returns a non-owning view of the payload.
+    [[nodiscard]] std::string_view as_string() const
     {
         const char* data = nullptr;
         size_t len = 0;
         check(tav_cbor_as_string(handle_, &data, &len), "as_string");
         return {data, len};
     }
-
-    std::string_view as_string() const&& = delete;
 
     [[nodiscard]] uint64_t as_tag() const
     {

--- a/ffi/include/tav/internal/cbor_abi.h
+++ b/ffi/include/tav/internal/cbor_abi.h
@@ -17,15 +17,14 @@ extern "C" {
  * contract. Not a supported interface on its own.
  *
  * Handles:
- * - A handle owns one CBOR value and every child below it, and is released
- *   with tav_cbor_free. tav_cbor_free(NULL) is a no-op.
+ * - Every handle is independently owned and keeps its complete immutable CBOR
+ *   document alive. Every handle is released with tav_cbor_free;
+ *   tav_cbor_free(NULL) is a no-op.
  * - Container constructors consume every handle passed to them and set each
- *   caller variable to NULL. Handles in a batch must be distinct; a repeated
- *   handle is consumed twice and so freed twice.
- * - A batch containing NULL is rejected, and any handle already consumed from
- *   it is returned to the caller's variables, possibly at a different address.
- * - Accessors return a borrowed handle, valid until its owning root is freed.
- *   A borrowed handle must not be freed or consumed.
+ *   caller variable to NULL. A batch containing NULL or the same handle more
+ *   than once is rejected without consuming any handles.
+ * - Navigation returns a new owning handle projected into the same immutable
+ *   document. It remains valid after the source handle is freed.
  *
  * Payloads:
  * - Scalars are copied. tav_cbor_make_bytes and tav_cbor_make_string borrow:
@@ -180,7 +179,9 @@ int tav_cbor_as_tag(const TavCborHandle* value, uint64_t* out);
 int tav_cbor_size(const TavCborHandle* value, size_t* out);
 
 /*
- * Navigation. Each writes a borrowed child through out.
+ * Navigation. Each writes a new owning handle through out. The output is
+ * cleared before any work, and must be released with tav_cbor_free or passed
+ * to a consuming container constructor.
  *
  * array_at: TYPE_MISMATCH if not an array, OUT_OF_BOUND past the end.
  * map_at:   TYPE_MISMATCH if not a map or if the key is a container, which a
@@ -188,13 +189,13 @@ int tav_cbor_size(const TavCborHandle* value, size_t* out);
  *           KEY_NOT_FOUND if absent.
  * tag_at:   TYPE_MISMATCH if not tagged, KEY_NOT_FOUND if the tag differs.
  */
-int tav_cbor_array_at(const TavCborHandle* value, size_t index, const TavCborHandle** out);
-int tav_cbor_map_at(const TavCborHandle* value, const TavCborHandle* key, const TavCborHandle** out);
-int tav_cbor_tag_at(const TavCborHandle* value, uint64_t tag, const TavCborHandle** out);
+int tav_cbor_array_at(const TavCborHandle* value, size_t index, TavCborHandle** out);
+int tav_cbor_map_at(const TavCborHandle* value, const TavCborHandle* key, TavCborHandle** out);
+int tav_cbor_tag_at(const TavCborHandle* value, uint64_t tag, TavCborHandle** out);
 
 /* Map enumeration, for callers that walk rather than look up. */
-int tav_cbor_map_key_at(const TavCborHandle* value, size_t index, const TavCborHandle** out);
-int tav_cbor_map_value_at(const TavCborHandle* value, size_t index, const TavCborHandle** out);
+int tav_cbor_map_key_at(const TavCborHandle* value, size_t index, TavCborHandle** out);
+int tav_cbor_map_value_at(const TavCborHandle* value, size_t index, TavCborHandle** out);
 
 #ifdef __cplusplus
 }

--- a/ffi/src/c_ffi/cbor.rs
+++ b/ffi/src/c_ffi/cbor.rs
@@ -81,16 +81,8 @@ fn into_view_handle(view: CborView) -> *mut TavCborHandle {
 ///
 /// # Safety
 /// `handle` must be null or a live handle.
-pub(crate) unsafe fn as_handle<'a>(handle: *const TavCborHandle) -> Option<&'a TavCborHandle> {
+unsafe fn as_handle<'a>(handle: *const TavCborHandle) -> Option<&'a TavCborHandle> {
     unsafe { handle.as_ref() }
-}
-
-/// Read a handle without taking ownership.
-///
-/// # Safety
-/// `handle` must be null or a live handle.
-pub(crate) unsafe fn as_value<'a>(handle: *const TavCborHandle) -> Option<&'a CborValue<'static>> {
-    unsafe { as_handle(handle) }.map(CborView::as_native)
 }
 
 /// View caller memory as a slice that outlives this call.
@@ -381,9 +373,10 @@ pub unsafe extern "C" fn tav_cbor_make_map(
         // Checked before anything is consumed, so a rejected batch leaves the
         // caller's handles intact.
         for i in (0..total).step_by(2) {
-            match unsafe { as_value(*pairs.add(i)) } {
-                Some(key) if !usable_as_key(key) => return std::ptr::null_mut(),
-                _ => {}
+            if let Some(key) = unsafe { as_handle(*pairs.add(i)) } {
+                if !usable_as_key(key.as_native()) {
+                    return std::ptr::null_mut();
+                }
             }
         }
         let Some(values) = (unsafe { take_all(pairs, total) }) else {
@@ -425,8 +418,8 @@ pub unsafe extern "C" fn tav_cbor_make_tagged(
 /// `value` must be null or a live handle.
 #[no_mangle]
 pub unsafe extern "C" fn tav_cbor_shallow_copy(value: *const TavCborHandle) -> *mut TavCborHandle {
-    guard_handle(|| match unsafe { as_value(value) } {
-        Some(value) => into_handle(value.clone()),
+    guard_handle(|| match unsafe { as_handle(value) } {
+        Some(value) => into_handle(value.as_native().clone()),
         None => std::ptr::null_mut(),
     })
 }
@@ -440,8 +433,8 @@ pub unsafe extern "C" fn tav_cbor_shallow_copy(value: *const TavCborHandle) -> *
 /// `value` must be null or a live handle.
 #[no_mangle]
 pub unsafe extern "C" fn tav_cbor_deep_copy(value: *const TavCborHandle) -> *mut TavCborHandle {
-    guard_handle(|| match unsafe { as_value(value) } {
-        Some(value) => into_handle(value.clone().into_owned()),
+    guard_handle(|| match unsafe { as_handle(value) } {
+        Some(value) => into_handle(value.as_native().clone().into_owned()),
         None => std::ptr::null_mut(),
     })
 }
@@ -472,7 +465,7 @@ unsafe fn serialize<M: Mode>(
     unsafe { reset_error(err_ptr, err_len) };
     let out_ok = unsafe { reset_owned_out(out_ptr) };
     let len_ok = unsafe { reset_scalar_out(out_len) };
-    let Some(value) = (unsafe { as_value(value) }) else {
+    let Some(handle) = (unsafe { as_handle(value) }) else {
         unsafe { set_error("Null CBOR handle", err_ptr, err_len) };
         return STATUS_ENCODE_FAILED;
     };
@@ -480,7 +473,10 @@ unsafe fn serialize<M: Mode>(
         unsafe { set_error("Null output pointer", err_ptr, err_len) };
         return STATUS_ENCODE_FAILED;
     }
-    match value.to_bytes_with_depth::<M>(capped(max_depth)) {
+    match handle
+        .as_native()
+        .to_bytes_with_depth::<M>(capped(max_depth))
+    {
         Ok(bytes) => {
             let bytes = bytes.into_boxed_slice();
             let len = bytes.len();
@@ -643,8 +639,8 @@ pub unsafe extern "C" fn tav_cbor_buffer_free(ptr: *mut u8, len: usize) {
 /// `value` must be null or a live handle.
 #[no_mangle]
 pub unsafe extern "C" fn tav_cbor_kind(value: *const TavCborHandle) -> i32 {
-    guard_status(KIND_INVALID, || match unsafe { as_value(value) } {
-        Some(value) => kind_of(value),
+    guard_status(KIND_INVALID, || match unsafe { as_handle(value) } {
+        Some(value) => kind_of(value.as_native()),
         None => KIND_INVALID,
     })
 }
@@ -659,7 +655,7 @@ pub unsafe extern "C" fn tav_cbor_as_signed(value: *const TavCborHandle, out: *m
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        match unsafe { as_value(value) } {
+        match unsafe { as_handle(value) }.map(CborView::as_native) {
             Some(CborValue::Int(v)) => {
                 unsafe { *out = *v };
                 STATUS_OK
@@ -679,7 +675,7 @@ pub unsafe extern "C" fn tav_cbor_as_simple(value: *const TavCborHandle, out: *m
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        match unsafe { as_value(value) } {
+        match unsafe { as_handle(value) }.map(CborView::as_native) {
             Some(CborValue::Simple(v)) => {
                 unsafe { *out = *v };
                 STATUS_OK
@@ -703,7 +699,7 @@ pub unsafe extern "C" fn tav_cbor_as_bytes(
         if out.is_null() || out_len.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        match unsafe { as_value(value) } {
+        match unsafe { as_handle(value) }.map(CborView::as_native) {
             Some(CborValue::ByteString(payload)) => {
                 unsafe {
                     *out = payload.as_ptr();
@@ -730,7 +726,7 @@ pub unsafe extern "C" fn tav_cbor_as_string(
         if out.is_null() || out_len.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        match unsafe { as_value(value) } {
+        match unsafe { as_handle(value) }.map(CborView::as_native) {
             Some(CborValue::TextString(payload)) => {
                 unsafe {
                     *out = payload.as_ptr().cast();
@@ -753,7 +749,7 @@ pub unsafe extern "C" fn tav_cbor_as_tag(value: *const TavCborHandle, out: *mut 
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        match unsafe { as_value(value) } {
+        match unsafe { as_handle(value) }.map(CborView::as_native) {
             Some(CborValue::Tagged { tag, .. }) => {
                 unsafe { *out = *tag };
                 STATUS_OK
@@ -773,7 +769,7 @@ pub unsafe extern "C" fn tav_cbor_size(value: *const TavCborHandle, out: *mut us
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        let count = match unsafe { as_value(value) } {
+        let count = match unsafe { as_handle(value) }.map(CborView::as_native) {
             Some(CborValue::Array(items)) => items.len(),
             Some(CborValue::Map(entries)) => entries.len(),
             _ => return STATUS_TYPE_MISMATCH,
@@ -846,9 +842,10 @@ pub unsafe extern "C" fn tav_cbor_map_at(
         let Some(handle) = (unsafe { as_handle(value) }) else {
             return STATUS_TYPE_MISMATCH;
         };
-        let Some(key) = (unsafe { as_value(key) }) else {
+        let Some(key) = (unsafe { as_handle(key) }) else {
             return STATUS_TYPE_MISMATCH;
         };
+        let key = key.as_native();
         if !usable_as_key(key) {
             return STATUS_TYPE_MISMATCH;
         }

--- a/ffi/src/c_ffi/cbor.rs
+++ b/ffi/src/c_ffi/cbor.rs
@@ -10,11 +10,10 @@
 //!
 //! # Handle ownership
 //!
-//! A handle owns one [`CborValue`] and every child below it. Container
-//! constructors consume the handles they are given and null the caller's
-//! variables. Each handle in a batch must be distinct: a repeated handle is
-//! consumed twice and so freed twice. Callers observing this obtain a tree,
-//! which the implementation assumes without validation.
+//! Every handle is independently owned and keeps its complete immutable CBOR
+//! document alive. Navigation returns a new owning handle projected into the
+//! same document. Container constructors consume the handles they are given,
+//! null the caller's variables, and materialize each selected subtree.
 //!
 //! # Payload ownership
 //!
@@ -30,10 +29,13 @@
 //! whatever depth the caller asks for.
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::os::raw::c_char;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use cbor::{CborValue, Det, Mode, Nondet};
+
+use crate::cbor_view::{CborView, NativeCborValue};
 
 /// Success.
 pub const STATUS_OK: i32 = 0;
@@ -63,16 +65,24 @@ pub const KIND_SIMPLE: i32 = 6;
 /// stack.
 pub const MAX_DEPTH_LIMIT: usize = 256;
 
-/// A CBOR value behind a C handle.
-///
-/// Byte and text payloads may point into caller memory, which the caller
-/// guarantees outlives this value.
-#[repr(transparent)]
-pub struct TavCborHandle(pub(crate) CborValue<'static>);
+/// An opaque, independently owned view into an immutable CBOR document.
+pub type TavCborHandle = CborView;
 
 /// Move `value` onto the heap and hand the caller an owning handle.
 pub(crate) fn into_handle(value: CborValue<'static>) -> *mut TavCborHandle {
-    Box::into_raw(Box::new(TavCborHandle(value)))
+    into_view_handle(CborView::from_native(value))
+}
+
+fn into_view_handle(view: CborView) -> *mut TavCborHandle {
+    Box::into_raw(Box::new(view))
+}
+
+/// Read a handle without taking ownership.
+///
+/// # Safety
+/// `handle` must be null or a live handle.
+pub(crate) unsafe fn as_handle<'a>(handle: *const TavCborHandle) -> Option<&'a TavCborHandle> {
+    unsafe { handle.as_ref() }
 }
 
 /// Read a handle without taking ownership.
@@ -80,15 +90,7 @@ pub(crate) fn into_handle(value: CborValue<'static>) -> *mut TavCborHandle {
 /// # Safety
 /// `handle` must be null or a live handle.
 pub(crate) unsafe fn as_value<'a>(handle: *const TavCborHandle) -> Option<&'a CborValue<'static>> {
-    unsafe { handle.as_ref() }.map(|h| &h.0)
-}
-
-/// Borrow a child as a handle.
-///
-/// Sound because [`TavCborHandle`] is `repr(transparent)` over [`CborValue`],
-/// so a child's own address serves as its handle.
-pub(crate) fn borrow(value: &CborValue<'static>) -> *const TavCborHandle {
-    (value as *const CborValue<'static>).cast()
+    unsafe { as_handle(handle) }.map(CborView::as_native)
 }
 
 /// View caller memory as a slice that outlives this call.
@@ -119,14 +121,11 @@ pub(crate) unsafe fn take(slot: *mut *mut TavCborHandle) -> Option<CborValue<'st
         return None;
     }
     unsafe { *slot = std::ptr::null_mut() };
-    Some(unsafe { Box::from_raw(handle) }.0)
+    let view = *unsafe { Box::from_raw(handle) };
+    Some(view.into_native())
 }
 
-/// Take ownership of `count` handles, returning those already taken if any
-/// slot is null.
-///
-/// Every slot must hold a distinct handle. A handle appearing twice is taken
-/// twice and so freed twice, which this does not detect.
+/// Take ownership of `count` distinct handles.
 ///
 /// # Safety
 /// `slots` must be valid for `count` handle variables holding distinct
@@ -142,19 +141,22 @@ pub(crate) unsafe fn take_all(
         return None;
     }
 
-    let mut taken = Vec::with_capacity(count);
-    for i in 0..count {
-        match unsafe { take(slots.add(i)) } {
-            Some(value) => taken.push(value),
-            None => {
-                for (j, value) in taken.into_iter().enumerate() {
-                    unsafe { *slots.add(j) = into_handle(value) };
-                }
-                return None;
-            }
+    let slots_slice = unsafe { std::slice::from_raw_parts_mut(slots, count) };
+    let mut distinct = HashSet::with_capacity(count);
+    for &handle in slots_slice.iter() {
+        if handle.is_null() || !distinct.insert(handle) {
+            return None;
         }
     }
-    Some(taken)
+
+    let views = slots_slice
+        .iter_mut()
+        .map(|slot| {
+            let handle = std::mem::replace(slot, std::ptr::null_mut());
+            *unsafe { Box::from_raw(handle) }
+        })
+        .collect::<Vec<_>>();
+    Some(views.into_iter().map(CborView::into_native).collect())
 }
 
 /// Build a byte string that borrows `payload`.
@@ -447,8 +449,8 @@ pub unsafe extern "C" fn tav_cbor_deep_copy(value: *const TavCborHandle) -> *mut
 /// Release an owning handle. Freeing null is a no-op.
 ///
 /// # Safety
-/// `value` must come from a constructor or a parse call, and must not have
-/// been released already. Borrowed handles must not be passed here.
+/// `value` must be null or a live handle returned by this API, and must not
+/// have been released already.
 #[no_mangle]
 pub unsafe extern "C" fn tav_cbor_free(value: *mut TavCborHandle) {
     if value.is_null() {
@@ -783,7 +785,14 @@ pub unsafe extern "C" fn tav_cbor_size(value: *const TavCborHandle, out: *mut us
 
 // --- Navigation ---
 
-/// Borrow an array element by index.
+fn project_handle(
+    handle: &TavCborHandle,
+    project: impl for<'a> FnOnce(&'a NativeCborValue) -> Result<[&'a NativeCborValue; 1], i32>,
+) -> Result<*mut TavCborHandle, i32> {
+    handle.project(project).map(|[view]| into_view_handle(view))
+}
+
+/// Return an independently owned array element by index.
 ///
 /// # Safety
 /// `value` must be null or a live handle, and `out` valid for writing.
@@ -791,26 +800,33 @@ pub unsafe extern "C" fn tav_cbor_size(value: *const TavCborHandle, out: *mut us
 pub unsafe extern "C" fn tav_cbor_array_at(
     value: *const TavCborHandle,
     index: usize,
-    out: *mut *const TavCborHandle,
+    out: *mut *mut TavCborHandle,
 ) -> i32 {
     guard_status(STATUS_TYPE_MISMATCH, || {
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        let Some(CborValue::Array(items)) = (unsafe { as_value(value) }) else {
+        unsafe { *out = std::ptr::null_mut() };
+        let Some(handle) = (unsafe { as_handle(value) }) else {
             return STATUS_TYPE_MISMATCH;
         };
-        match items.get(index) {
-            Some(item) => {
-                unsafe { *out = borrow(item) };
+        match project_handle(handle, |value| match value {
+            CborValue::Array(items) => items
+                .get(index)
+                .map(|item| [item])
+                .ok_or(STATUS_OUT_OF_BOUND),
+            _ => Err(STATUS_TYPE_MISMATCH),
+        }) {
+            Ok(projected) => {
+                unsafe { *out = projected };
                 STATUS_OK
             }
-            None => STATUS_OUT_OF_BOUND,
+            Err(status) => status,
         }
     })
 }
 
-/// Borrow a map value by key.
+/// Return an independently owned map value by key.
 ///
 /// Containers are not usable as keys and are reported as a type mismatch.
 ///
@@ -820,13 +836,14 @@ pub unsafe extern "C" fn tav_cbor_array_at(
 pub unsafe extern "C" fn tav_cbor_map_at(
     value: *const TavCborHandle,
     key: *const TavCborHandle,
-    out: *mut *const TavCborHandle,
+    out: *mut *mut TavCborHandle,
 ) -> i32 {
     guard_status(STATUS_TYPE_MISMATCH, || {
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        let Some(CborValue::Map(entries)) = (unsafe { as_value(value) }) else {
+        unsafe { *out = std::ptr::null_mut() };
+        let Some(handle) = (unsafe { as_handle(value) }) else {
             return STATUS_TYPE_MISMATCH;
         };
         let Some(key) = (unsafe { as_value(key) }) else {
@@ -835,17 +852,24 @@ pub unsafe extern "C" fn tav_cbor_map_at(
         if !usable_as_key(key) {
             return STATUS_TYPE_MISMATCH;
         }
-        match entries.iter().find(|(k, _)| k == key) {
-            Some((_, found)) => {
-                unsafe { *out = borrow(found) };
+        match project_handle(handle, |value| match value {
+            CborValue::Map(entries) => entries
+                .iter()
+                .find(|(candidate, _)| candidate == key)
+                .map(|(_, found)| [found])
+                .ok_or(STATUS_KEY_NOT_FOUND),
+            _ => Err(STATUS_TYPE_MISMATCH),
+        }) {
+            Ok(projected) => {
+                unsafe { *out = projected };
                 STATUS_OK
             }
-            None => STATUS_KEY_NOT_FOUND,
+            Err(status) => status,
         }
     })
 }
 
-/// Borrow the payload of a tagged value, checking the tag.
+/// Return an independently owned tagged payload, checking the tag.
 ///
 /// # Safety
 /// `value` must be null or a live handle, and `out` valid for writing.
@@ -853,28 +877,34 @@ pub unsafe extern "C" fn tav_cbor_map_at(
 pub unsafe extern "C" fn tav_cbor_tag_at(
     value: *const TavCborHandle,
     tag: u64,
-    out: *mut *const TavCborHandle,
+    out: *mut *mut TavCborHandle,
 ) -> i32 {
     guard_status(STATUS_TYPE_MISMATCH, || {
         if out.is_null() {
             return STATUS_TYPE_MISMATCH;
         }
-        let Some(CborValue::Tagged {
-            tag: actual,
-            payload,
-        }) = (unsafe { as_value(value) })
-        else {
+        unsafe { *out = std::ptr::null_mut() };
+        let Some(handle) = (unsafe { as_handle(value) }) else {
             return STATUS_TYPE_MISMATCH;
         };
-        if *actual != tag {
-            return STATUS_KEY_NOT_FOUND;
+        match project_handle(handle, |value| match value {
+            CborValue::Tagged {
+                tag: actual,
+                payload,
+            } if *actual == tag => Ok([payload]),
+            CborValue::Tagged { .. } => Err(STATUS_KEY_NOT_FOUND),
+            _ => Err(STATUS_TYPE_MISMATCH),
+        }) {
+            Ok(projected) => {
+                unsafe { *out = projected };
+                STATUS_OK
+            }
+            Err(status) => status,
         }
-        unsafe { *out = borrow(payload) };
-        STATUS_OK
     })
 }
 
-/// Borrow a map key by entry index.
+/// Return an independently owned map key by entry index.
 ///
 /// # Safety
 /// `value` must be null or a live handle, and `out` valid for writing.
@@ -882,14 +912,14 @@ pub unsafe extern "C" fn tav_cbor_tag_at(
 pub unsafe extern "C" fn tav_cbor_map_key_at(
     value: *const TavCborHandle,
     index: usize,
-    out: *mut *const TavCborHandle,
+    out: *mut *mut TavCborHandle,
 ) -> i32 {
     guard_status(STATUS_TYPE_MISMATCH, || unsafe {
         cbor_map_entry_at(value, index, out, true)
     })
 }
 
-/// Borrow a map value by entry index.
+/// Return an independently owned map value by entry index.
 ///
 /// # Safety
 /// `value` must be null or a live handle, and `out` valid for writing.
@@ -897,7 +927,7 @@ pub unsafe extern "C" fn tav_cbor_map_key_at(
 pub unsafe extern "C" fn tav_cbor_map_value_at(
     value: *const TavCborHandle,
     index: usize,
-    out: *mut *const TavCborHandle,
+    out: *mut *mut TavCborHandle,
 ) -> i32 {
     guard_status(STATUS_TYPE_MISMATCH, || unsafe {
         cbor_map_entry_at(value, index, out, false)
@@ -907,20 +937,27 @@ pub unsafe extern "C" fn tav_cbor_map_value_at(
 unsafe fn cbor_map_entry_at(
     value: *const TavCborHandle,
     index: usize,
-    out: *mut *const TavCborHandle,
+    out: *mut *mut TavCborHandle,
     want_key: bool,
 ) -> i32 {
     if out.is_null() {
         return STATUS_TYPE_MISMATCH;
     }
-    let Some(CborValue::Map(entries)) = (unsafe { as_value(value) }) else {
+    unsafe { *out = std::ptr::null_mut() };
+    let Some(handle) = (unsafe { as_handle(value) }) else {
         return STATUS_TYPE_MISMATCH;
     };
-    match entries.get(index) {
-        Some((key, item)) => {
-            unsafe { *out = borrow(if want_key { key } else { item }) };
+    match project_handle(handle, |value| match value {
+        CborValue::Map(entries) => entries
+            .get(index)
+            .map(|(key, item)| [if want_key { key } else { item }])
+            .ok_or(STATUS_OUT_OF_BOUND),
+        _ => Err(STATUS_TYPE_MISMATCH),
+    }) {
+        Ok(projected) => {
+            unsafe { *out = projected };
             STATUS_OK
         }
-        None => STATUS_OUT_OF_BOUND,
+        Err(status) => status,
     }
 }

--- a/ffi/src/c_ffi/cbor_tests.rs
+++ b/ffi/src/c_ffi/cbor_tests.rs
@@ -307,6 +307,17 @@ fn container_constructors_consume_their_children() {
 }
 
 #[test]
+fn a_repeated_handle_is_rejected_without_consuming_the_batch() {
+    let handle = tav_cbor_make_signed(1);
+    let mut items = [handle, handle];
+
+    assert!(unsafe { tav_cbor_make_array(items.as_mut_ptr(), items.len()) }.is_null());
+    assert_eq!(items, [handle, handle]);
+
+    unsafe { tav_cbor_free(handle) };
+}
+
+#[test]
 fn a_container_cannot_be_a_map_key() {
     // Every key a map holds must be one tav_cbor_map_at can compare.
     for key in [
@@ -580,13 +591,15 @@ fn a_tagged_value_has_no_size() {
 fn array_indexing_reports_out_of_bounds_separately_from_type() {
     let document = [0x81, 0x01];
     let handle = parse_nondet(&document).unwrap();
-    let mut out: *const TavCborHandle = ptr::null();
+    let mut out: *mut TavCborHandle = ptr::null_mut();
 
     assert_eq!(unsafe { tav_cbor_array_at(handle, 0, &mut out) }, STATUS_OK);
+    unsafe { tav_cbor_free(out) };
     assert_eq!(
         unsafe { tav_cbor_array_at(handle, 1, &mut out) },
         STATUS_OUT_OF_BOUND
     );
+    assert!(out.is_null());
     unsafe { tav_cbor_free(handle) };
 
     let scalar = tav_cbor_make_signed(1);
@@ -602,7 +615,7 @@ fn map_lookup_matches_by_value() {
     // {1: 2, "a": 3}
     let document = [0xa2, 0x01, 0x02, 0x61, 0x61, 0x03];
     let handle = parse_nondet(&document).unwrap();
-    let mut out: *const TavCborHandle = ptr::null();
+    let mut out: *mut TavCborHandle = ptr::null_mut();
 
     let int_key = tav_cbor_make_signed(1);
     assert_eq!(
@@ -612,6 +625,7 @@ fn map_lookup_matches_by_value() {
     let mut found = 0i64;
     assert_eq!(unsafe { tav_cbor_as_signed(out, &mut found) }, STATUS_OK);
     assert_eq!(found, 2);
+    unsafe { tav_cbor_free(out) };
     unsafe { tav_cbor_free(int_key) };
 
     let text = b"a";
@@ -620,6 +634,7 @@ fn map_lookup_matches_by_value() {
         unsafe { tav_cbor_map_at(handle, text_key, &mut out) },
         STATUS_OK
     );
+    unsafe { tav_cbor_free(out) };
     unsafe { tav_cbor_free(text_key) };
 
     let absent = tav_cbor_make_signed(9);
@@ -627,6 +642,7 @@ fn map_lookup_matches_by_value() {
         unsafe { tav_cbor_map_at(handle, absent, &mut out) },
         STATUS_KEY_NOT_FOUND
     );
+    assert!(out.is_null());
     unsafe { tav_cbor_free(absent) };
 
     unsafe { tav_cbor_free(handle) };
@@ -657,7 +673,7 @@ fn parsing_rejects_a_container_used_as_a_map_key() {
 fn containers_are_not_usable_as_map_keys() {
     let document = [0xa1, 0x01, 0x02];
     let handle = parse_nondet(&document).unwrap();
-    let mut out: *const TavCborHandle = ptr::null();
+    let mut out: *mut TavCborHandle = ptr::null_mut();
 
     let container_key = unsafe { tav_cbor_make_array(ptr::null_mut(), 0) };
     assert_eq!(
@@ -672,13 +688,15 @@ fn containers_are_not_usable_as_map_keys() {
 fn tag_lookup_distinguishes_a_wrong_tag_from_a_wrong_kind() {
     let document = [0xd2, 0x01];
     let handle = parse_nondet(&document).unwrap();
-    let mut out: *const TavCborHandle = ptr::null();
+    let mut out: *mut TavCborHandle = ptr::null_mut();
 
     assert_eq!(unsafe { tav_cbor_tag_at(handle, 18, &mut out) }, STATUS_OK);
+    unsafe { tav_cbor_free(out) };
     assert_eq!(
         unsafe { tav_cbor_tag_at(handle, 19, &mut out) },
         STATUS_KEY_NOT_FOUND
     );
+    assert!(out.is_null());
     unsafe { tav_cbor_free(handle) };
 
     let scalar = tav_cbor_make_signed(1);
@@ -711,7 +729,7 @@ fn a_tag_can_be_read_before_it_is_known() {
 fn map_enumeration_walks_entries_in_order() {
     let document = [0xa2, 0x01, 0x02, 0x03, 0x04];
     let handle = parse_nondet(&document).unwrap();
-    let mut out: *const TavCborHandle = ptr::null();
+    let mut out: *mut TavCborHandle = ptr::null_mut();
 
     for (index, (key, value)) in [(1i64, 2i64), (3, 4)].iter().enumerate() {
         assert_eq!(
@@ -721,6 +739,7 @@ fn map_enumeration_walks_entries_in_order() {
         let mut found = 0i64;
         assert_eq!(unsafe { tav_cbor_as_signed(out, &mut found) }, STATUS_OK);
         assert_eq!(found, *key);
+        unsafe { tav_cbor_free(out) };
 
         assert_eq!(
             unsafe { tav_cbor_map_value_at(handle, index, &mut out) },
@@ -728,24 +747,27 @@ fn map_enumeration_walks_entries_in_order() {
         );
         assert_eq!(unsafe { tav_cbor_as_signed(out, &mut found) }, STATUS_OK);
         assert_eq!(found, *value);
+        unsafe { tav_cbor_free(out) };
     }
 
     assert_eq!(
         unsafe { tav_cbor_map_key_at(handle, 2, &mut out) },
         STATUS_OUT_OF_BOUND
     );
+    assert!(out.is_null());
     unsafe { tav_cbor_free(handle) };
 }
 
 #[test]
-fn a_borrowed_child_stays_valid_while_the_root_lives() {
+fn an_owned_child_stays_valid_after_the_root_is_freed() {
     let document = [0x82, 0x42, 0xaa, 0xbb, 0x01];
     let handle = parse_nondet(&document).unwrap();
-    let mut child: *const TavCborHandle = ptr::null();
+    let mut child: *mut TavCborHandle = ptr::null_mut();
     assert_eq!(
         unsafe { tav_cbor_array_at(handle, 0, &mut child) },
         STATUS_OK
     );
+    unsafe { tav_cbor_free(handle) };
 
     let (mut out, mut out_len) = (ptr::null(), 0usize);
     assert_eq!(
@@ -756,7 +778,53 @@ fn a_borrowed_child_stays_valid_while_the_root_lives() {
         unsafe { std::slice::from_raw_parts(out, out_len) },
         [0xaa, 0xbb]
     );
+    unsafe { tav_cbor_free(child) };
+}
+
+#[test]
+fn a_projected_child_can_be_consumed_by_a_builder() {
+    let document = [0x81, 0x01];
+    let handle = parse_nondet(&document).unwrap();
+    let mut child: *mut TavCborHandle = ptr::null_mut();
+    assert_eq!(
+        unsafe { tav_cbor_array_at(handle, 0, &mut child) },
+        STATUS_OK
+    );
     unsafe { tav_cbor_free(handle) };
+
+    let mut items = [child];
+    let rebuilt = unsafe { tav_cbor_make_array(items.as_mut_ptr(), items.len()) };
+    assert!(!rebuilt.is_null());
+    assert!(items[0].is_null());
+    assert_eq!(encode_det(rebuilt).unwrap(), document);
+    unsafe { tav_cbor_free(rebuilt) };
+}
+
+#[test]
+fn a_root_and_its_projection_can_be_consumed_in_either_order() {
+    for root_first in [true, false] {
+        let document = [0x81, 0x01];
+        let root = parse_nondet(&document).unwrap();
+        let mut child: *mut TavCborHandle = ptr::null_mut();
+        assert_eq!(unsafe { tav_cbor_array_at(root, 0, &mut child) }, STATUS_OK);
+
+        let mut items = if root_first {
+            [root, child]
+        } else {
+            [child, root]
+        };
+        let rebuilt = unsafe { tav_cbor_make_array(items.as_mut_ptr(), items.len()) };
+
+        assert!(!rebuilt.is_null());
+        assert_eq!(items, [ptr::null_mut(), ptr::null_mut()]);
+        let expected = if root_first {
+            vec![0x82, 0x81, 0x01, 0x01] // [[1], 1]
+        } else {
+            vec![0x82, 0x01, 0x81, 0x01] // [1, [1]]
+        };
+        assert_eq!(encode_det(rebuilt).unwrap(), expected);
+        unsafe { tav_cbor_free(rebuilt) };
+    }
 }
 
 // --- The C contract ---

--- a/ffi/src/cbor_view.rs
+++ b/ffi/src/cbor_view.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use cose::CborValue;
 
-/// A document detached from any input buffer, so the view can own it.
+/// A CBOR value stored behind a native FFI handle.
 pub(crate) type NativeCborValue = CborValue<'static>;
 
 #[derive(Clone)]
@@ -23,7 +23,13 @@ pub struct CborView {
 impl CborView {
     /// Detaches `value` from any input buffer, which a view outlives.
     pub(crate) fn new(value: CborValue<'_>) -> Self {
-        let document = Arc::new(value.into_owned());
+        Self::from_native(value.into_owned())
+    }
+
+    /// Takes ownership of a value whose borrowed payloads already satisfy the
+    /// native FFI's lifetime contract.
+    pub(crate) fn from_native(value: NativeCborValue) -> Self {
+        let document = Arc::new(value);
         let node = Arc::as_ptr(&document);
         Self { document, node }
     }
@@ -46,5 +52,74 @@ impl CborView {
             document: Arc::clone(&self.document),
             node,
         }))
+    }
+
+    /// Materializes this view for insertion into a new document.
+    ///
+    /// An unshared root moves without cloning. Shared roots and projections
+    /// clone the selected subtree while preserving borrowed payloads.
+    pub(crate) fn into_native(self) -> NativeCborValue {
+        let Self { document, node } = self;
+        if node == Arc::as_ptr(&document) {
+            Arc::try_unwrap(document).unwrap_or_else(|document| (*document).clone())
+        } else {
+            // SAFETY: `node` points into `document`, which remains alive until
+            // after the selected subtree has been cloned.
+            unsafe { (&*node).clone() }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use super::*;
+
+    fn owned_bytes(bytes: Vec<u8>) -> NativeCborValue {
+        NativeCborValue::ByteString(Cow::Owned(bytes))
+    }
+
+    fn payload_ptr(value: &NativeCborValue) -> *const u8 {
+        match value {
+            NativeCborValue::ByteString(bytes) => bytes.as_ptr(),
+            _ => panic!("expected byte string"),
+        }
+    }
+
+    #[test]
+    fn a_unique_root_moves_its_owned_payload() {
+        let view = CborView::from_native(owned_bytes(vec![1, 2, 3]));
+        let before = payload_ptr(view.as_native());
+
+        let value = view.into_native();
+
+        assert_eq!(payload_ptr(&value), before);
+    }
+
+    #[test]
+    fn a_shared_root_clones_its_owned_payload() {
+        let view = CborView::from_native(owned_bytes(vec![1, 2, 3]));
+        let shared = view.clone();
+        let before = payload_ptr(view.as_native());
+
+        let value = shared.into_native();
+
+        assert_ne!(payload_ptr(&value), before);
+        assert_eq!(value, *view.as_native());
+    }
+
+    #[test]
+    fn a_projection_clones_only_its_selected_subtree() {
+        let root = CborView::from_native(NativeCborValue::Array(vec![owned_bytes(vec![1, 2, 3])]));
+        let [projection] = root
+            .project(|value| value.array_at(0).map(|child| [child]))
+            .unwrap();
+        let before = payload_ptr(projection.as_native());
+
+        let value = projection.into_native();
+
+        assert_ne!(payload_ptr(&value), before);
+        assert_eq!(value, *root.as_native().array_at(0).unwrap());
     }
 }

--- a/ffi/tests/c-builder/cbor_builder.cpp
+++ b/ffi/tests/c-builder/cbor_builder.cpp
@@ -25,12 +25,18 @@ static_assert(std::is_move_constructible_v<Value>);
 static_assert(std::is_move_assignable_v<Value>);
 static_assert(!std::is_constructible_v<Value, TavCborHandle*>);
 
-// A Ref outlives a temporary Value, so only an lvalue can be borrowed.
 template <typename T>
-concept Borrowable = requires(T&& value) { std::forward<T>(value).ref(); };
-static_assert(Borrowable<Value&>);
-static_assert(Borrowable<const Value&>);
-static_assert(!Borrowable<Value&&>);
+concept ByteViewable = requires(T&& value) {
+    std::forward<T>(value).as_bytes();
+};
+template <typename T>
+concept StringViewable = requires(T&& value) {
+    std::forward<T>(value).as_string();
+};
+static_assert(ByteViewable<const Value&>);
+static_assert(!ByteViewable<Value&&>);
+static_assert(StringViewable<const Value&>);
+static_assert(!StringViewable<Value&&>);
 
 namespace {
 
@@ -48,8 +54,8 @@ TEST_CASE("cbor handle: signed round trips")
         const Value built = make_signed(value);
         const std::vector<uint8_t> encoded = built.det_serialize();
         const Value parsed = nondet_parse(encoded);
-        CHECK(parsed.ref().kind() == Kind::SIGNED);
-        CHECK(parsed.ref().as_signed() == value);
+        CHECK(parsed.kind() == Kind::SIGNED);
+        CHECK(parsed.as_signed() == value);
     }
 }
 
@@ -60,8 +66,8 @@ TEST_CASE("cbor handle: simple round trips")
     CHECK(encoded == std::vector<uint8_t>{0xf6});
 
     const Value parsed = nondet_parse(encoded);
-    CHECK(parsed.ref().kind() == Kind::SIMPLE);
-    CHECK(parsed.ref().as_simple() == 22);
+    CHECK(parsed.kind() == Kind::SIMPLE);
+    CHECK(parsed.as_simple() == 22);
 }
 
 TEST_CASE("cbor handle: bytes round trip")
@@ -72,8 +78,8 @@ TEST_CASE("cbor handle: bytes round trip")
     CHECK(encoded == std::vector<uint8_t>{0x43, 1, 2, 3});
 
     const Value parsed = nondet_parse(encoded);
-    CHECK(parsed.ref().kind() == Kind::BYTES);
-    CHECK(vec(parsed.ref().as_bytes()) == payload);
+    CHECK(parsed.kind() == Kind::BYTES);
+    CHECK(vec(parsed.as_bytes()) == payload);
 }
 
 TEST_CASE("cbor handle: string round trips")
@@ -84,8 +90,8 @@ TEST_CASE("cbor handle: string round trips")
     CHECK(encoded == std::vector<uint8_t>{0x62, 0x68, 0x69});
 
     const Value parsed = nondet_parse(encoded);
-    CHECK(parsed.ref().kind() == Kind::STRING);
-    CHECK(parsed.ref().as_string() == "hi");
+    CHECK(parsed.kind() == Kind::STRING);
+    CHECK(parsed.as_string() == "hi");
 }
 
 TEST_CASE("cbor handle: array round trips")
@@ -100,11 +106,12 @@ TEST_CASE("cbor handle: array round trips")
     CHECK(encoded == std::vector<uint8_t>{0x82, 0x01, 0x62, 0x68, 0x69});
 
     const Value parsed = nondet_parse(encoded);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
     CHECK(root.kind() == Kind::ARRAY);
     REQUIRE(root.size() == 2);
     CHECK(root.array_at(0).as_signed() == 1);
-    CHECK(root.array_at(1).as_string() == "hi");
+    const Value text_value = root.array_at(1);
+    CHECK(text_value.as_string() == "hi");
 }
 
 TEST_CASE("cbor handle: map round trips, det sorts keys, and lookup is by key")
@@ -124,16 +131,17 @@ TEST_CASE("cbor handle: map round trips, det sorts keys, and lookup is by key")
     CHECK(encoded == std::vector<uint8_t>{0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x02});
 
     const Value parsed = nondet_parse(encoded);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
     CHECK(root.kind() == Kind::MAP);
     REQUIRE(root.size() == 2);
 
     // Lookup by key, as ValueImpl::map_at does.
     const Value key_a = make_string(a);
-    CHECK(root.map_at(key_a.ref()).as_signed() == 1);
+    CHECK(root.map_at(key_a).as_signed() == 1);
 
     // Enumeration, for callers that walk.
-    CHECK(root.map_key_at(1).as_string() == "b");
+    const Value second_key = root.map_key_at(1);
+    CHECK(second_key.as_string() == "b");
     CHECK(root.map_value_at(1).as_signed() == 2);
 }
 
@@ -145,9 +153,10 @@ TEST_CASE("cbor handle: tagged round trips and tag_at checks the tag")
     CHECK(encoded == std::vector<uint8_t>{0xd2, 0x41, 0x2a});
 
     const Value parsed = nondet_parse(encoded);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
     CHECK(root.kind() == Kind::TAGGED);
-    CHECK(vec(root.tag_at(18).as_bytes()) == payload);
+    const Value tagged_payload = root.tag_at(18);
+    CHECK(vec(tagged_payload.as_bytes()) == payload);
 }
 
 TEST_CASE("cbor handle: payloads are borrowed, not copied")
@@ -157,13 +166,13 @@ TEST_CASE("cbor handle: payloads are borrowed, not copied")
     // the safe proof.
     const std::vector<uint8_t> buffer = {1, 2, 3};
     const Value built = make_bytes(buffer);
-    CHECK(built.ref().as_bytes().data() == buffer.data());
+    CHECK(built.as_bytes().data() == buffer.data());
 
     // The same holds for a parsed document: its payload points into the input.
     const std::vector<uint8_t> document = {0x43, 1, 2, 3};
     const Value parsed = nondet_parse(document);
-    CHECK(parsed.ref().as_bytes().data() == document.data() + 1);
-    CHECK(vec(parsed.ref().as_bytes()) == std::vector<uint8_t>{1, 2, 3});
+    CHECK(parsed.as_bytes().data() == document.data() + 1);
+    CHECK(vec(parsed.as_bytes()) == std::vector<uint8_t>{1, 2, 3});
 }
 
 TEST_CASE("cbor handle: det_parse accepts a canonical encoding and round trips")
@@ -175,12 +184,13 @@ TEST_CASE("cbor handle: det_parse accepts a canonical encoding and round trips")
     const std::vector<uint8_t> encoded = built.det_serialize();
 
     const Value parsed = det_parse(encoded);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
     CHECK(root.kind() == Kind::MAP);
     CHECK(root.size() == 2);
 
     const Value one = make_signed(1);
-    CHECK(root.map_at(one.ref()).as_string() == "one");
+    const Value found = root.map_at(one);
+    CHECK(found.as_string() == "one");
     CHECK(parsed.det_serialize() == encoded);
 }
 
@@ -188,7 +198,7 @@ TEST_CASE("cbor handle: errors carry the ABI status")
 {
     const std::vector<uint8_t> document = {0x81, 0x01}; // [1]
     const Value parsed = nondet_parse(document);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
 
     CHECK_THROWS_AS((void)root.array_at(5), CborError);
     try
@@ -227,7 +237,7 @@ TEST_CASE("cbor handle: errors carry the ABI status")
     CHECK_NOTHROW(nondet_parse(non_canonical));
 
     const Value canonical_parsed = det_parse(canonical);
-    CHECK(canonical_parsed.ref().as_signed() == 1);
+    CHECK(canonical_parsed.as_signed() == 1);
 
     try
     {
@@ -257,9 +267,36 @@ TEST_CASE("cbor handle: an empty value cannot be placed in a container")
     items.push_back(make_signed(1));
     items.emplace_back();
 
-    // The first handle is consumed, then the empty slot fails the call, and
-    // whatever was handed back is released.
+    // The ABI rejects the complete batch, then the wrapper releases the
+    // handles it had taken from the source values.
     CHECK_THROWS_AS(make_array(std::move(items)), CborError);
+}
+
+TEST_CASE("cbor handle: navigation returns an independently owned value")
+{
+    Value child;
+    {
+        const std::vector<uint8_t> document = {0x81, 0x18, 0x2a}; // [42]
+        const Value parsed = nondet_parse(document);
+        child = parsed.array_at(0);
+    }
+
+    CHECK(child.as_signed() == 42);
+}
+
+TEST_CASE("cbor handle: a projected value can be consumed by a builder")
+{
+    const std::vector<uint8_t> document = {0x81, 0x18, 0x2a}; // [42]
+    const Value parsed = nondet_parse(document);
+    Value child = parsed.array_at(0);
+
+    std::vector<Value> fields;
+    fields.push_back(std::move(child));
+    const Value rebuilt = make_array(std::move(fields));
+
+    CHECK(child.empty());
+    CHECK(rebuilt.det_serialize() == document);
+    CHECK(parsed.det_serialize() == document);
 }
 
 TEST_CASE("cbor handle: a nested document survives build, serialize, parse and walk")
@@ -277,12 +314,15 @@ TEST_CASE("cbor handle: a nested document survives build, serialize, parse and w
 
     const std::vector<uint8_t> encoded = sign1.det_serialize();
     const Value parsed = nondet_parse(encoded);
-    const Ref body = parsed.ref().tag_at(18);
+    const Value body = parsed.tag_at(18);
     REQUIRE(body.size() == 4);
-    CHECK(vec(body.array_at(0).as_bytes()) == phdr);
+    const Value parsed_phdr = body.array_at(0);
+    CHECK(vec(parsed_phdr.as_bytes()) == phdr);
     CHECK(body.array_at(1).size() == 0);
-    CHECK(vec(body.array_at(2).as_bytes()) == payload);
-    CHECK(vec(body.array_at(3).as_bytes()) == signature);
+    const Value parsed_payload = body.array_at(2);
+    CHECK(vec(parsed_payload.as_bytes()) == payload);
+    const Value parsed_signature = body.array_at(3);
+    CHECK(vec(parsed_signature.as_bytes()) == signature);
 }
 
 TEST_CASE("cbor handle: decode and encode failures are distinguishable")
@@ -292,7 +332,7 @@ TEST_CASE("cbor handle: decode and encode failures are distinguishable")
 
     const std::vector<uint8_t> document = {0x81, 0x01}; // [1]
     const Value parsed = nondet_parse(document);
-    CHECK_THROWS_AS((void)parsed.ref().as_signed(), DecodeError);
+    CHECK_THROWS_AS((void)parsed.as_signed(), DecodeError);
 
     // Nesting deeper than the serializer is allowed to walk.
     std::vector<Value> inner;
@@ -325,7 +365,7 @@ TEST_CASE("cbor handle: simple values convert to and from booleans")
 
     // SimpleValue feeds make_simple directly.
     const Value null_value = make_simple(SimpleValue::Null);
-    CHECK(null_value.ref().as_simple() == SimpleValue::Null);
+    CHECK(null_value.as_simple() == SimpleValue::Null);
     CHECK(null_value.det_serialize() == std::vector<uint8_t>{0xf6});
 }
 
@@ -349,14 +389,14 @@ TEST_CASE("cbor handle: rethrow_with_msg prefixes decode errors only")
     const Value parsed = nondet_parse(document);
 
     // The value is returned untouched when nothing throws.
-    const Ref item =
-      rethrow_with_msg([&] { return parsed.ref().array_at(0); }, "reading");
+    const Value item =
+      rethrow_with_msg([&] { return parsed.array_at(0); }, "reading");
     CHECK(item.as_signed() == 1);
 
     try
     {
         (void)rethrow_with_msg(
-          [&] { return parsed.ref().array_at(9); }, "reading item");
+          [&] { return parsed.array_at(9); }, "reading item");
         FAIL("expected a DecodeError");
     }
     catch (const DecodeError& e)
@@ -368,7 +408,7 @@ TEST_CASE("cbor handle: rethrow_with_msg prefixes decode errors only")
     // Without a message the original error passes through unchanged.
     try
     {
-        (void)rethrow_with_msg([&] { return parsed.ref().array_at(9); });
+        (void)rethrow_with_msg([&] { return parsed.array_at(9); });
         FAIL("expected a DecodeError");
     }
     catch (const DecodeError& e)
@@ -401,15 +441,18 @@ TEST_CASE("cbor handle: map lookup by key round trips")
       'e',
       'e'};
     const Value parsed = nondet_parse(document);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
 
     REQUIRE(root.size() == 3);
     const Value one = make_signed(1);
     const Value two = make_signed(2);
     const Value three = make_signed(3);
-    CHECK(root.map_at(one.ref()).as_string() == "one");
-    CHECK(root.map_at(two.ref()).as_string() == "two");
-    CHECK(root.map_at(three.ref()).as_string() == "three");
+    const Value found_one = root.map_at(one);
+    const Value found_two = root.map_at(two);
+    const Value found_three = root.map_at(three);
+    CHECK(found_one.as_string() == "one");
+    CHECK(found_two.as_string() == "two");
+    CHECK(found_three.as_string() == "three");
 
     CHECK(parsed.nondet_serialize() == document);
 }
@@ -419,16 +462,16 @@ TEST_CASE("cbor handle: shallow_copy shares payload buffers, deep_copy does not"
     const std::vector<uint8_t> payload = {0xaa, 0xbb};
     const Value source = make_bytes(payload);
 
-    const Value shared = shallow_copy(source.ref());
-    const Value detached = deep_copy(source.ref());
+    const Value shared = shallow_copy(source);
+    const Value detached = deep_copy(source);
 
     // Same bytes either way.
-    CHECK(vec(shared.ref().as_bytes()) == payload);
-    CHECK(vec(detached.ref().as_bytes()) == payload);
+    CHECK(vec(shared.as_bytes()) == payload);
+    CHECK(vec(detached.as_bytes()) == payload);
 
     // The shallow copy points at the caller's buffer; the deep copy does not.
-    CHECK(shared.ref().as_bytes().data() == payload.data());
-    CHECK(detached.ref().as_bytes().data() != payload.data());
+    CHECK(shared.as_bytes().data() == payload.data());
+    CHECK(detached.as_bytes().data() != payload.data());
 
     // Both are values in their own right, so both outlive the source value.
     CHECK(shared.det_serialize() == detached.det_serialize());
@@ -440,7 +483,7 @@ TEST_CASE("cbor handle: deep_copy outlives the buffer it was taken from")
     {
         const std::vector<uint8_t> document = {0x43, 0x01, 0x02, 0x03};
         const Value parsed = nondet_parse(document);
-        detached = deep_copy(parsed.ref());
+        detached = deep_copy(parsed);
         // parsed and document both die here.
     }
     CHECK(detached.det_serialize() == std::vector<uint8_t>{0x43, 0x01, 0x02, 0x03});
@@ -461,15 +504,15 @@ TEST_CASE("cbor handle: copying reproduces every kind")
       make_tagged(EPOCH_DATE_TIME, make_array(std::move(items)));
     const std::vector<uint8_t> expected = source.det_serialize();
 
-    CHECK(shallow_copy(source.ref()).det_serialize() == expected);
-    CHECK(deep_copy(source.ref()).det_serialize() == expected);
+    CHECK(shallow_copy(source).det_serialize() == expected);
+    CHECK(deep_copy(source).det_serialize() == expected);
 }
 
 TEST_CASE("cbor handle: an empty value cannot be copied")
 {
     const Value empty;
-    CHECK_THROWS_AS((void)shallow_copy(empty.ref()), EncodeError);
-    CHECK_THROWS_AS((void)deep_copy(empty.ref()), EncodeError);
+    CHECK_THROWS_AS((void)shallow_copy(empty), EncodeError);
+    CHECK_THROWS_AS((void)deep_copy(empty), EncodeError);
 }
 
 TEST_CASE("cbor handle: rebuilding a map with one entry replaced")
@@ -480,12 +523,12 @@ TEST_CASE("cbor handle: rebuilding a map with one entry replaced")
     original.emplace_back(make_signed(2), make_string("replace"));
     const Value source = make_map(std::move(original));
 
-    const Ref map = source.ref();
+    const Value& map = source;
     std::vector<MapItem> rebuilt;
     rebuilt.reserve(map.size());
     for (size_t i = 0; i < map.size(); ++i)
     {
-        const Ref key = map.map_key_at(i);
+        const Value key = map.map_key_at(i);
         const bool hit = key.kind() == Kind::SIGNED && key.as_signed() == 2;
         rebuilt.emplace_back(
           shallow_copy(key), hit ? make_signed(0) : shallow_copy(map.map_value_at(i)));
@@ -494,10 +537,12 @@ TEST_CASE("cbor handle: rebuilding a map with one entry replaced")
 
     const Value one = make_signed(1);
     const Value two = make_signed(2);
-    CHECK(edited.ref().map_at(one.ref()).as_string() == "keep");
-    CHECK(edited.ref().map_at(two.ref()).as_signed() == 0);
+    const Value kept = edited.map_at(one);
+    CHECK(kept.as_string() == "keep");
+    CHECK(edited.map_at(two).as_signed() == 0);
     // The source is untouched.
-    CHECK(source.ref().map_at(two.ref()).as_string() == "replace");
+    const Value original_value = source.map_at(two);
+    CHECK(original_value.as_string() == "replace");
 }
 
 TEST_CASE("cbor handle: rebuilding an array with one element replaced")
@@ -509,7 +554,7 @@ TEST_CASE("cbor handle: rebuilding an array with one element replaced")
     original.push_back(make_string("keep too"));
     const Value source = make_array(std::move(original));
 
-    const Ref array = source.ref();
+    const Value& array = source;
     std::vector<Value> rebuilt;
     rebuilt.reserve(array.size());
     for (size_t i = 0; i < array.size(); ++i)
@@ -518,13 +563,16 @@ TEST_CASE("cbor handle: rebuilding an array with one element replaced")
     }
     const Value edited = make_array(std::move(rebuilt));
 
-    const Ref result = edited.ref();
+    const Value& result = edited;
     REQUIRE(result.size() == 3);
-    CHECK(result.array_at(0).as_string() == "keep");
+    const Value first = result.array_at(0);
+    CHECK(first.as_string() == "keep");
     CHECK(result.array_at(1).as_signed() == 0);
-    CHECK(result.array_at(2).as_string() == "keep too");
+    const Value third = result.array_at(2);
+    CHECK(third.as_string() == "keep too");
     // The source is untouched.
-    CHECK(source.ref().array_at(1).as_string() == "replace");
+    const Value original_value = source.array_at(1);
+    CHECK(original_value.as_string() == "replace");
 }
 
 TEST_CASE("cbor handle: shallow_copy keeps an owned payload owned")
@@ -535,21 +583,21 @@ TEST_CASE("cbor handle: shallow_copy keeps an owned payload owned")
     {
         const std::vector<uint8_t> buffer = {0xaa, 0xbb, 0xcc};
         const Value borrowing = make_bytes(buffer);
-        const Value source = deep_copy(borrowing.ref());
-        copied = shallow_copy(source.ref());
-        CHECK(copied.ref().as_bytes().data() != source.ref().as_bytes().data());
+        const Value source = deep_copy(borrowing);
+        copied = shallow_copy(source);
+        CHECK(copied.as_bytes().data() != source.as_bytes().data());
     }
-    CHECK(vec(copied.ref().as_bytes()) == std::vector<uint8_t>{0xaa, 0xbb, 0xcc});
+    CHECK(vec(copied.as_bytes()) == std::vector<uint8_t>{0xaa, 0xbb, 0xcc});
 }
 
 TEST_CASE("cbor handle: shallow_copy keeps a borrowed payload borrowed")
 {
     const std::vector<uint8_t> buffer = {0x01, 0x02};
     const Value source = make_bytes(buffer);
-    const Value copied = shallow_copy(source.ref());
+    const Value copied = shallow_copy(source);
 
     // Shared with the caller's buffer, so nothing was duplicated.
-    CHECK(copied.ref().as_bytes().data() == buffer.data());
+    CHECK(copied.as_bytes().data() == buffer.data());
 }
 
 TEST_CASE("cbor handle: serialization stops one level past the depth ceiling")
@@ -567,14 +615,14 @@ TEST_CASE("cbor handle: serialization stops one level past the depth ceiling")
 
     const Value at_ceiling = nest(MAX_DEPTH);
     CHECK_NOTHROW((void)at_ceiling.det_serialize());
-    CHECK_NOTHROW((void)deep_copy(at_ceiling.ref()));
+    CHECK_NOTHROW((void)deep_copy(at_ceiling));
 
     const Value past_ceiling = nest(MAX_DEPTH + 1);
     CHECK_THROWS_AS((void)past_ceiling.det_serialize(), EncodeError);
 
     // Copying carries no depth limit of its own, so it still succeeds.
-    CHECK_NOTHROW((void)deep_copy(past_ceiling.ref()));
-    CHECK_NOTHROW((void)shallow_copy(past_ceiling.ref()));
+    CHECK_NOTHROW((void)deep_copy(past_ceiling));
+    CHECK_NOTHROW((void)shallow_copy(past_ceiling));
 }
 
 TEST_CASE("cbor handle: every key a map holds can be looked up")
@@ -587,14 +635,15 @@ TEST_CASE("cbor handle: every key a map holds can be looked up")
     entries.emplace_back(make_simple(SimpleValue::Null), make_string("by simple"));
     const Value map = make_map(std::move(entries));
 
-    const Ref root = map.ref();
+    const Value& root = map;
     REQUIRE(root.size() == 4);
     for (size_t i = 0; i < root.size(); ++i)
     {
         // The key the map hands back always finds its own entry.
-        CHECK(
-          root.map_at(root.map_key_at(i)).as_string() ==
-          root.map_value_at(i).as_string());
+        const Value key = root.map_key_at(i);
+        const Value found = root.map_at(key);
+        const Value enumerated = root.map_value_at(i);
+        CHECK(found.as_string() == enumerated.as_string());
     }
 }
 
@@ -632,13 +681,13 @@ TEST_CASE("cbor handle: every key of a parsed map can be looked up")
 
     const std::vector<uint8_t> encoded = built.det_serialize();
     const Value parsed = det_parse(encoded);
-    const Ref root = parsed.ref();
+    const Value& root = parsed;
 
     // Enumeration and lookup agree: whatever map_key_at hands back, map_at
     // accepts.
     for (size_t i = 0; i < root.size(); ++i)
     {
-        const Ref key = root.map_key_at(i);
+        const Value key = root.map_key_at(i);
         CHECK_NOTHROW((void)root.map_at(key));
     }
 }
@@ -646,13 +695,13 @@ TEST_CASE("cbor handle: every key of a parsed map can be looked up")
 TEST_CASE("cbor handle: as_tag reads the tag a tagged value carries")
 {
     const Value tagged = make_tagged(18, make_signed(7));
-    CHECK(tagged.ref().as_tag() == 18);
+    CHECK(tagged.as_tag() == 18);
     // The tag is needed to reach the payload, which tag_at only checks.
-    CHECK(tagged.ref().tag_at(tagged.ref().as_tag()).as_signed() == 7);
+    CHECK(tagged.tag_at(tagged.as_tag()).as_signed() == 7);
 
     // Anything else is a mismatch rather than a silent zero.
     const Value untagged = make_signed(1);
-    CHECK_THROWS_AS((void)untagged.ref().as_tag(), DecodeError);
+    CHECK_THROWS_AS((void)untagged.as_tag(), DecodeError);
 }
 
 TEST_CASE("cbor handle: moving transfers the handle and releases the target's own")
@@ -684,6 +733,6 @@ TEST_CASE("cbor handle: empty containers round trip")
 
     const Value array = make_array({});
     const Value map = make_map({});
-    CHECK(array.ref().size() == 0);
-    CHECK(map.ref().size() == 0);
+    CHECK(array.size() == 0);
+    CHECK(map.size() == 0);
 }

--- a/ffi/tests/c-builder/cbor_builder.cpp
+++ b/ffi/tests/c-builder/cbor_builder.cpp
@@ -25,19 +25,6 @@ static_assert(std::is_move_constructible_v<Value>);
 static_assert(std::is_move_assignable_v<Value>);
 static_assert(!std::is_constructible_v<Value, TavCborHandle*>);
 
-template <typename T>
-concept ByteViewable = requires(T&& value) {
-    std::forward<T>(value).as_bytes();
-};
-template <typename T>
-concept StringViewable = requires(T&& value) {
-    std::forward<T>(value).as_string();
-};
-static_assert(ByteViewable<const Value&>);
-static_assert(!ByteViewable<Value&&>);
-static_assert(StringViewable<const Value&>);
-static_assert(!StringViewable<Value&&>);
-
 namespace {
 
 std::vector<uint8_t> vec(std::span<const uint8_t> data)
@@ -537,12 +524,10 @@ TEST_CASE("cbor handle: rebuilding a map with one entry replaced")
 
     const Value one = make_signed(1);
     const Value two = make_signed(2);
-    const Value kept = edited.map_at(one);
-    CHECK(kept.as_string() == "keep");
+    CHECK(edited.map_at(one).as_string() == "keep");
     CHECK(edited.map_at(two).as_signed() == 0);
     // The source is untouched.
-    const Value original_value = source.map_at(two);
-    CHECK(original_value.as_string() == "replace");
+    CHECK(source.map_at(two).as_string() == "replace");
 }
 
 TEST_CASE("cbor handle: rebuilding an array with one element replaced")
@@ -565,14 +550,11 @@ TEST_CASE("cbor handle: rebuilding an array with one element replaced")
 
     const Value& result = edited;
     REQUIRE(result.size() == 3);
-    const Value first = result.array_at(0);
-    CHECK(first.as_string() == "keep");
+    CHECK(result.array_at(0).as_string() == "keep");
     CHECK(result.array_at(1).as_signed() == 0);
-    const Value third = result.array_at(2);
-    CHECK(third.as_string() == "keep too");
+    CHECK(result.array_at(2).as_string() == "keep too");
     // The source is untouched.
-    const Value original_value = source.array_at(1);
-    CHECK(original_value.as_string() == "replace");
+    CHECK(source.array_at(1).as_string() == "replace");
 }
 
 TEST_CASE("cbor handle: shallow_copy keeps an owned payload owned")


### PR DESCRIPTION
Replace layout-compatible borrowed child pointers with independently owned handles backed by the existing Arc-based CBOR document view. This removes the internal repr(transparent) coupling and lets every navigation result be freed or transferred to a consuming builder uniformly.

Builders move unique roots without cloning and materialize shared roots or projected subtrees only when required. The C++ wrapper now exposes one move-only Value type instead of Value/Ref, while span and string_view results retain normal non-owning C++ lifetime semantics. Duplicate handles are rejected before a batch is consumed.

Validated with the native FFI suite, the C++ consumer suite, a C11 header compile, and the focused CBOR ownership and C ABI suites under Miri.
